### PR TITLE
65 sign in parent

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -5,4 +5,5 @@
   <section class="filled">
     <mat-slide-toggle [(ngModel)]="signedIn">Toggle me!{{signedIn}}</mat-slide-toggle>
   </section>
+  <app-sign-in></app-sign-in>
 </main>

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -2,8 +2,12 @@
   <header>
     <app-navbar [signedIn]="signedIn"></app-navbar>
   </header>
-  <section class="filled">
-    <mat-slide-toggle [(ngModel)]="signedIn">Toggle me!{{signedIn}}</mat-slide-toggle>
+  <section>
+    <router-outlet *ngIf="signedIn; else elseBlock"></router-outlet>
+    <ng-template #elseBlock>
+      <app-sign-in
+        (signIn)="this.signedIn = true"
+      ></app-sign-in>
+    </ng-template>
   </section>
-  <app-sign-in></app-sign-in>
 </main>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -3,11 +3,12 @@ import { RouterOutlet } from '@angular/router';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { FormsModule } from '@angular/forms';
 import { NavbarComponent } from './navbar/navbar.component';
+import { SignInComponent } from './sign-in/sign-in.component';
 
 @Component({
   selector: 'app-root',
   standalone: true,
-  imports: [RouterOutlet, MatSlideToggleModule, FormsModule, NavbarComponent],
+  imports: [RouterOutlet, MatSlideToggleModule, FormsModule, NavbarComponent, SignInComponent],
   templateUrl: './app.component.html',
   styleUrl: './app.component.scss'
 })

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,4 +1,5 @@
 import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
 import { RouterOutlet } from '@angular/router';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { FormsModule } from '@angular/forms';
@@ -8,7 +9,7 @@ import { SignInComponent } from './sign-in/sign-in.component';
 @Component({
   selector: 'app-root',
   standalone: true,
-  imports: [RouterOutlet, MatSlideToggleModule, FormsModule, NavbarComponent, SignInComponent],
+  imports: [CommonModule, RouterOutlet, MatSlideToggleModule, FormsModule, NavbarComponent, SignInComponent],
   templateUrl: './app.component.html',
   styleUrl: './app.component.scss'
 })

--- a/src/app/navbar/navbar.component.html
+++ b/src/app/navbar/navbar.component.html
@@ -1,11 +1,11 @@
 <header>
   <div class="container" *ngIf="signedIn; else elseBlock">
     <a class="ponder-name">Ponder</a>
-    
+
     <div class="search-bar">
       put search bar component here
     </div>
-      
+
     <nav>
       <ul>
         <li><button mat-icon-button aria-label="Create Set Button with a plus icon" class="circle-button">
@@ -15,11 +15,11 @@
           <mat-icon class="symbol">logout</mat-icon>
         </button></li>
       </ul>
-    </nav> 
+    </nav>
   </div>
   <ng-template #elseBlock>
     <div class="container">
       <h1 class="ponder-name">Ponder</h1>
     </div>
-  </ng-template> 
+  </ng-template>
 </header>

--- a/src/app/sign-in/sign-in.component.html
+++ b/src/app/sign-in/sign-in.component.html
@@ -1,0 +1,1 @@
+<button class = sign-in>Sign In with Google. Placeholder.</button>

--- a/src/app/sign-in/sign-in.component.html
+++ b/src/app/sign-in/sign-in.component.html
@@ -1,1 +1,5 @@
-<button class = sign-in>Sign In with Google. Placeholder.</button>
+<section>
+  <button class = "sign-in"
+    (click)="this.signIn.emit(true)">Sign In with Google. Placeholder.
+  </button>
+</section>

--- a/src/app/sign-in/sign-in.component.scss
+++ b/src/app/sign-in/sign-in.component.scss
@@ -1,0 +1,7 @@
+.sign-in {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  padding: 10px;
+}

--- a/src/app/sign-in/sign-in.component.spec.ts
+++ b/src/app/sign-in/sign-in.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SignInComponent } from './sign-in.component';
+
+describe('SignInComponent', () => {
+  let component: SignInComponent;
+  let fixture: ComponentFixture<SignInComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [SignInComponent]
+    })
+    .compileComponents();
+    
+    fixture = TestBed.createComponent(SignInComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/sign-in/sign-in.component.ts
+++ b/src/app/sign-in/sign-in.component.ts
@@ -1,0 +1,12 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-sign-in',
+  standalone: true,
+  imports: [],
+  templateUrl: './sign-in.component.html',
+  styleUrl: './sign-in.component.scss'
+})
+export class SignInComponent {
+
+}

--- a/src/app/sign-in/sign-in.component.ts
+++ b/src/app/sign-in/sign-in.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, EventEmitter, Output } from '@angular/core';
 
 @Component({
   selector: 'app-sign-in',
@@ -8,5 +8,5 @@ import { Component } from '@angular/core';
   styleUrl: './sign-in.component.scss'
 })
 export class SignInComponent {
-
+  @Output() signIn = new EventEmitter<any>();
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -28,4 +28,7 @@ html {
 /* You can add global styles to this file, and also import other style files */
 
 html, body { height: 100%; }
-body { margin: 0;}
+body {
+  margin: 0;
+  background-color: mat.get-theme-color(theme.$ponder-light-theme, background);
+}


### PR DESCRIPTION
Fixes #65 

- Created Sign In parent component
- Added a Sign in but to mimic sign in. Sign in will be implemented in #54 
- Turned the global background color to the background color used in Figma

Notes:
- If I should make another issue and pull request that is specifically for the background color, I can do that instead of changing it in here.