### PR TITLE
Create study sequence card pool

### DIFF
--- a/src/app/card-pool/card-pool.component.html
+++ b/src/app/card-pool/card-pool.component.html
@@ -1,5 +1,5 @@
-<div style="overflow-y: scroll; height: 100%;">
-  <div class="padding-medium" style="display: grid; grid-template-columns: 1fr 1fr 1fr; grid-gap: 32px; overflow: visible;">
+<div class="scroll-box">
+  <div class="card-pool padding-medium">
     @for(fMap of flashcardsMap; track flashcardsMap) {
       <div [ngClass]="{'hide': !fMap[1].show}">
         <app-sequence-card

--- a/src/app/card-pool/card-pool.component.html
+++ b/src/app/card-pool/card-pool.component.html
@@ -1,17 +1,12 @@
-<!-- dynamically assign columns -->
-<!-- <mat-grid-list id="card-pool" cols="3">
-  @for(fMap of flashcardsMap; track flashcardsMap) {
-    <mat-grid-tile>
-      <app-sequence-card [flashcard]="fMap[1].card" (removeFromSeqEvent)="addToSeq(fMap[1])"></app-sequence-card>
-    </mat-grid-tile>
-  }
-</mat-grid-list> -->
 <div style="overflow-y: scroll; height: 100%;">
-<div class="padding-medium" style="display: grid; grid-template-columns: 1fr 1fr 1fr; grid-gap: 32px; overflow: visible;">
-  @for(fMap of flashcardsMap; track flashcardsMap) {
-    <div [ngClass]="{'hide': !fMap[1].show}">
-      <app-sequence-card [flashcard]="fMap[1].card" (addToSeqEvent)="addToSeq(fMap[1])"></app-sequence-card>
-    </div>
-  }
-</div>
+  <div class="padding-medium" style="display: grid; grid-template-columns: 1fr 1fr 1fr; grid-gap: 32px; overflow: visible;">
+    @for(fMap of flashcardsMap; track flashcardsMap) {
+      <div [ngClass]="{'hide': !fMap[1].show}">
+        <app-sequence-card
+          [flashcard]="fMap[1].card"
+          (addToSeqEvent)="addToSeq({key: fMap[0], card: fMap[1].card})">
+        </app-sequence-card>
+      </div>
+    }
+  </div>
 </div>

--- a/src/app/card-pool/card-pool.component.html
+++ b/src/app/card-pool/card-pool.component.html
@@ -1,8 +1,17 @@
 <!-- dynamically assign columns -->
-<mat-grid-list id="card-pool" cols="{{this.flashcardsMap?.size}}">
+<!-- <mat-grid-list id="card-pool" cols="3">
   @for(fMap of flashcardsMap; track flashcardsMap) {
     <mat-grid-tile>
-      <app-sequence-card [flashcard]="fMap[1].card" (removeFromSeqEvent)="addToSeq(fMap[1])" cdkDrag></app-sequence-card>
+      <app-sequence-card [flashcard]="fMap[1].card" (removeFromSeqEvent)="addToSeq(fMap[1])"></app-sequence-card>
     </mat-grid-tile>
   }
-</mat-grid-list>
+</mat-grid-list> -->
+<div style="overflow-y: scroll; height: 100%;">
+<div class="padding-medium" style="display: grid; grid-template-columns: 1fr 1fr 1fr; grid-gap: 32px; overflow: visible;">
+  @for(fMap of flashcardsMap; track flashcardsMap) {
+    <div [ngClass]="{'hide': !fMap[1].show}">
+      <app-sequence-card [flashcard]="fMap[1].card" (addToSeqEvent)="addToSeq(fMap[1])"></app-sequence-card>
+    </div>
+  }
+</div>
+</div>

--- a/src/app/card-pool/card-pool.component.html
+++ b/src/app/card-pool/card-pool.component.html
@@ -2,7 +2,7 @@
 <mat-grid-list id="card-pool" cols="{{this.flashcardsMap?.size}}">
   @for(fMap of flashcardsMap; track flashcardsMap) {
     <mat-grid-tile>
-      <app-sequence-card [flashcard]="fMap[0]" (removeFromSeqEvent)="addToSeq(fMap[0], fMap[1])" cdkDrag></app-sequence-card>
+      <app-sequence-card [flashcard]="fMap[1].card" (removeFromSeqEvent)="addToSeq(fMap[1])" cdkDrag></app-sequence-card>
     </mat-grid-tile>
   }
 </mat-grid-list>

--- a/src/app/card-pool/card-pool.component.html
+++ b/src/app/card-pool/card-pool.component.html
@@ -1,12 +1,11 @@
-<div class="scroll-box">
-  <div class="card-pool padding-medium">
-    @for(fMap of flashcardsMap; track flashcardsMap) {
-      <div [ngClass]="{'hide': !fMap[1].show}">
-        <app-sequence-card
-          [flashcard]="fMap[1].card"
-          (addToSeqEvent)="addToSeq({key: fMap[0], card: fMap[1].card})">
-        </app-sequence-card>
-      </div>
-    }
-  </div>
+<div class="card-pool padding-medium">
+  @for(fMap of flashcardsMap; track flashcardsMap) {
+    <div [ngClass]="{'hide': !fMap[1].show}">
+      <app-sequence-card
+        [flashcard]="fMap[1].card"
+        (addToSeqEvent)="addToSeq({key: fMap[0], card: fMap[1].card})">
+      </app-sequence-card>
+    </div>
+  }
 </div>
+

--- a/src/app/card-pool/card-pool.component.html
+++ b/src/app/card-pool/card-pool.component.html
@@ -1,0 +1,8 @@
+<!-- dynamically assign columns -->
+<mat-grid-list id="card-pool" cols="{{this.flashcardsMap?.size}}">
+  @for(fMap of flashcardsMap; track flashcardsMap) {
+    <mat-grid-tile>
+      <app-sequence-card [flashcard]="fMap[0]" (removeFromSeqEvent)="addToSeq(fMap[0], fMap[1])" cdkDrag></app-sequence-card>
+    </mat-grid-tile>
+  }
+</mat-grid-list>

--- a/src/app/card-pool/card-pool.component.scss
+++ b/src/app/card-pool/card-pool.component.scss
@@ -1,0 +1,7 @@
+mat-grid-tile {
+  padding-top: 16 !important;
+}
+
+.hide {
+  visibility: hidden;
+}

--- a/src/app/card-pool/card-pool.component.scss
+++ b/src/app/card-pool/card-pool.component.scss
@@ -1,8 +1,3 @@
-.scroll-box {
-  overflow-y: scroll;
-  height: 100%;
-}
-
 .card-pool {
   display: grid;
   grid-template-columns: 1fr 1fr 1fr;

--- a/src/app/card-pool/card-pool.component.scss
+++ b/src/app/card-pool/card-pool.component.scss
@@ -1,5 +1,13 @@
-mat-grid-tile {
-  padding-top: 16 !important;
+.scroll-box {
+  overflow-y: scroll;
+  height: 100%;
+}
+
+.card-pool {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  grid-gap: 32px;
+  overflow: visible;
 }
 
 .hide {

--- a/src/app/card-pool/card-pool.component.spec.ts
+++ b/src/app/card-pool/card-pool.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CardPoolComponent } from './card-pool.component';
+
+describe('CardPoolComponent', () => {
+  let component: CardPoolComponent;
+  let fixture: ComponentFixture<CardPoolComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [CardPoolComponent]
+    })
+    .compileComponents();
+    
+    fixture = TestBed.createComponent(CardPoolComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/card-pool/card-pool.component.ts
+++ b/src/app/card-pool/card-pool.component.ts
@@ -1,0 +1,25 @@
+import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { FlashcardData } from '../data-models/flashcard-model';
+import { MatGridListModule } from '@angular/material/grid-list';
+import { SequenceCardComponent } from '../sequence-card/sequence-card.component';
+import { DragDropModule } from '@angular/cdk/drag-drop';
+
+@Component({
+  selector: 'app-card-pool',
+  standalone: true,
+  imports: [MatGridListModule, SequenceCardComponent, DragDropModule],
+  templateUrl: './card-pool.component.html',
+  styleUrl: './card-pool.component.scss'
+})
+export class CardPoolComponent {
+  flashcardsMap?: Map<FlashcardData, boolean> = new Map<FlashcardData, boolean>([
+    [new FlashcardData("1"), true],
+    [new FlashcardData("2"), true],
+    [new FlashcardData("3"), true],
+  ]);
+  @Output() addToSeqEvent: EventEmitter<FlashcardData> = new EventEmitter();
+  addToSeq(flashcard: FlashcardData, show: boolean) {
+    this.flashcardsMap?.set(flashcard, show);
+    this.addToSeqEvent.emit(flashcard);
+  }
+}

--- a/src/app/card-pool/card-pool.component.ts
+++ b/src/app/card-pool/card-pool.component.ts
@@ -5,12 +5,11 @@ import { SequenceCardComponent } from '../sequence-card/sequence-card.component'
 import { DragDropModule } from '@angular/cdk/drag-drop';
 import { CommonModule } from '@angular/common';
 import { Observable, Subscription } from 'rxjs';
+import { CardMap } from '../study-sequence/study-sequence.component';
 
 interface PoolItem {
   card: FlashcardData,
   show: boolean,
-  x: number,
-  y: number,
 }
 
 @Component({
@@ -22,29 +21,28 @@ interface PoolItem {
 })
 export class CardPoolComponent {
   private visSubscription?: Subscription;
-  flashcardsMap?: Map<string, PoolItem> = new Map<string, PoolItem>([
-    ["1", {card: new FlashcardData("1"), show:true, x:0, y:0}],
-    ["2", {card: new FlashcardData("2"), show:true, x:0, y:0}],
-    ["3", {card: new FlashcardData("3"), show:true, x:0, y:0}],
-    ["4", {card: new FlashcardData("4"), show:true, x:0, y:0}],
-    ["5", {card: new FlashcardData("5"), show:true, x:0, y:0}],
-    ["6", {card: new FlashcardData("6"), show:true, x:0, y:0}],
-    ["7", {card: new FlashcardData("7"), show:true, x:0, y:0}],
-    ["8", {card: new FlashcardData("8"), show:true, x:0, y:0}],
-  ]);
-  @Output() addToSeqEvent: EventEmitter<FlashcardData> = new EventEmitter();
-  @Input() visUpdates?: Observable<string>;
+  flashcardsMap: Map<number, PoolItem> = new Map<number, PoolItem>();
+  @Output() addToSeqEvent: EventEmitter<CardMap> = new EventEmitter();
+  @Input() visUpdates?: Observable<CardMap>;
+  @Input() set cardPool(items: CardMap[]) {
+    const temp = new Map<number, PoolItem>()
+    items.map(item => {
+      temp.set(item.key, {card: item.card, show: true});
+    });
+    this.flashcardsMap = temp;
+  }
 
   ngOnInit() {
-    this.visSubscription = this.visUpdates!.subscribe(fid => this.updateVisibility(fid))
+    this.visSubscription = this.visUpdates!
+      .subscribe(item => this.updateVisibility(item.key))
   }
 
-  addToSeq(item: PoolItem) {
-    item.show = false;
-    this.addToSeqEvent.emit(item.card);
+  addToSeq(item: CardMap) {
+    this.flashcardsMap.get(item.key)!.show = false;
+    this.addToSeqEvent.emit(item);
   }
 
-  updateVisibility(fid: string) {
+  updateVisibility(fid: number) {
     this.flashcardsMap!.get(fid)!.show = true;
   }
 }

--- a/src/app/card-pool/card-pool.component.ts
+++ b/src/app/card-pool/card-pool.component.ts
@@ -1,10 +1,8 @@
 import { Component, Input, Output, EventEmitter } from '@angular/core';
 import { FlashcardData } from '../data-models/flashcard-model';
-import { MatGridListModule } from '@angular/material/grid-list';
 import { SequenceCardComponent } from '../sequence-card/sequence-card.component';
-import { DragDropModule } from '@angular/cdk/drag-drop';
 import { CommonModule } from '@angular/common';
-import { Observable, Subscription } from 'rxjs';
+import { Observable } from 'rxjs';
 import { CardMap } from '../study-sequence/study-sequence.component';
 
 interface PoolItem {
@@ -15,7 +13,7 @@ interface PoolItem {
 @Component({
   selector: 'app-card-pool',
   standalone: true,
-  imports: [MatGridListModule, SequenceCardComponent, DragDropModule, CommonModule],
+  imports: [SequenceCardComponent, CommonModule],
   templateUrl: './card-pool.component.html',
   styleUrl: './card-pool.component.scss'
 })

--- a/src/app/card-pool/card-pool.component.ts
+++ b/src/app/card-pool/card-pool.component.ts
@@ -3,6 +3,8 @@ import { FlashcardData } from '../data-models/flashcard-model';
 import { MatGridListModule } from '@angular/material/grid-list';
 import { SequenceCardComponent } from '../sequence-card/sequence-card.component';
 import { DragDropModule } from '@angular/cdk/drag-drop';
+import { CommonModule } from '@angular/common';
+import { Observable, Subscription } from 'rxjs';
 
 interface PoolItem {
   card: FlashcardData,
@@ -14,20 +16,35 @@ interface PoolItem {
 @Component({
   selector: 'app-card-pool',
   standalone: true,
-  imports: [MatGridListModule, SequenceCardComponent, DragDropModule],
+  imports: [MatGridListModule, SequenceCardComponent, DragDropModule, CommonModule],
   templateUrl: './card-pool.component.html',
   styleUrl: './card-pool.component.scss'
 })
 export class CardPoolComponent {
+  private visSubscription?: Subscription;
   flashcardsMap?: Map<string, PoolItem> = new Map<string, PoolItem>([
-    ["1", {card: new FlashcardData("1"), show:false, x:0, y:0}],
-    ["2", {card: new FlashcardData("2"), show:false, x:0, y:0}],
-    ["3", {card: new FlashcardData("1"), show:false, x:0, y:0}],
+    ["1", {card: new FlashcardData("1"), show:true, x:0, y:0}],
+    ["2", {card: new FlashcardData("2"), show:true, x:0, y:0}],
+    ["3", {card: new FlashcardData("3"), show:true, x:0, y:0}],
+    ["4", {card: new FlashcardData("4"), show:true, x:0, y:0}],
+    ["5", {card: new FlashcardData("5"), show:true, x:0, y:0}],
+    ["6", {card: new FlashcardData("6"), show:true, x:0, y:0}],
+    ["7", {card: new FlashcardData("7"), show:true, x:0, y:0}],
+    ["8", {card: new FlashcardData("8"), show:true, x:0, y:0}],
   ]);
   @Output() addToSeqEvent: EventEmitter<FlashcardData> = new EventEmitter();
+  @Input() visUpdates?: Observable<string>;
+
+  ngOnInit() {
+    this.visSubscription = this.visUpdates!.subscribe(fid => this.updateVisibility(fid))
+  }
 
   addToSeq(item: PoolItem) {
     item.show = false;
     this.addToSeqEvent.emit(item.card);
+  }
+
+  updateVisibility(fid: string) {
+    this.flashcardsMap!.get(fid)!.show = true;
   }
 }

--- a/src/app/card-pool/card-pool.component.ts
+++ b/src/app/card-pool/card-pool.component.ts
@@ -4,6 +4,13 @@ import { MatGridListModule } from '@angular/material/grid-list';
 import { SequenceCardComponent } from '../sequence-card/sequence-card.component';
 import { DragDropModule } from '@angular/cdk/drag-drop';
 
+interface PoolItem {
+  card: FlashcardData,
+  show: boolean,
+  x: number,
+  y: number,
+}
+
 @Component({
   selector: 'app-card-pool',
   standalone: true,
@@ -12,14 +19,15 @@ import { DragDropModule } from '@angular/cdk/drag-drop';
   styleUrl: './card-pool.component.scss'
 })
 export class CardPoolComponent {
-  flashcardsMap?: Map<FlashcardData, boolean> = new Map<FlashcardData, boolean>([
-    [new FlashcardData("1"), true],
-    [new FlashcardData("2"), true],
-    [new FlashcardData("3"), true],
+  flashcardsMap?: Map<string, PoolItem> = new Map<string, PoolItem>([
+    ["1", {card: new FlashcardData("1"), show:false, x:0, y:0}],
+    ["2", {card: new FlashcardData("2"), show:false, x:0, y:0}],
+    ["3", {card: new FlashcardData("1"), show:false, x:0, y:0}],
   ]);
   @Output() addToSeqEvent: EventEmitter<FlashcardData> = new EventEmitter();
-  addToSeq(flashcard: FlashcardData, show: boolean) {
-    this.flashcardsMap?.set(flashcard, show);
-    this.addToSeqEvent.emit(flashcard);
+
+  addToSeq(item: PoolItem) {
+    item.show = false;
+    this.addToSeqEvent.emit(item.card);
   }
 }

--- a/src/app/card-pool/card-pool.component.ts
+++ b/src/app/card-pool/card-pool.component.ts
@@ -20,7 +20,6 @@ interface PoolItem {
   styleUrl: './card-pool.component.scss'
 })
 export class CardPoolComponent {
-  private visSubscription?: Subscription;
   flashcardsMap: Map<number, PoolItem> = new Map<number, PoolItem>();
   @Output() addToSeqEvent: EventEmitter<CardMap> = new EventEmitter();
   @Input() visUpdates?: Observable<CardMap>;
@@ -33,8 +32,7 @@ export class CardPoolComponent {
   }
 
   ngOnInit() {
-    this.visSubscription = this.visUpdates!
-      .subscribe(item => this.updateVisibility(item.key))
+    this.visUpdates!.subscribe(item => this.updateVisibility(item.key));
   }
 
   addToSeq(item: CardMap) {

--- a/src/app/data-models/studyset-model.ts
+++ b/src/app/data-models/studyset-model.ts
@@ -214,6 +214,11 @@ export class StudySetData implements StudySetModel {
       this.flashcards.splice(index, 1);
     }
   }
+
+  /** Returns a list of flashcards not in the sequence */
+  getCardsNotInSeq(sequence: SequenceData) {
+    return this.flashcards.filter(card => sequence.cardList.indexOf(card) < 0);
+  }
 }
 
 

--- a/src/app/flashcard-editor/flashcard-editor.component.html
+++ b/src/app/flashcard-editor/flashcard-editor.component.html
@@ -10,7 +10,7 @@
         </div>
       }
     </div>
-    <button mat-fab  extended id="add-button"class="button" (click)="addCard()">
+    <button mat-fab  extended id="add-button" class="button" (click)="addCard()">
       <mat-icon>add</mat-icon>
       Add Card
     </button>

--- a/src/app/flashcard/flashcard.component.html
+++ b/src/app/flashcard/flashcard.component.html
@@ -5,14 +5,14 @@
       <div class="front">
         <mat-icon aria-hidden="false" aria-label="Flip icon" fontIcon="autorenew" class="arrow"></mat-icon>
         <div class = "front-content">
-          {{ frontText }}
+          {{ flashcard.term }}
         </div>
         <ng-template [ngTemplateOutlet]="addOns"></ng-template>
       </div>
       <div class="back">
         <mat-icon aria-hidden="false" aria-label="Flip icon" fontIcon="autorenew" class="arrow"></mat-icon>
         <div class = "back-content">
-          {{ backText }}
+          {{ flashcard.definition }}
         </div>
         <ng-template [ngTemplateOutlet]="addOns"></ng-template>
       </div>

--- a/src/app/flashcard/flashcard.component.scss
+++ b/src/app/flashcard/flashcard.component.scss
@@ -34,7 +34,7 @@
     grid-template-columns: 8% auto 8%;
   }
 
-  .mat-icon.notranslate.arrow.material-icons.mat-ligature-font.mat-icon-no-color {
+  .arrow {
     margin-top: 8px;
     grid-column: 1 / 2;
     width: 40px;

--- a/src/app/flashcard/flashcard.component.scss
+++ b/src/app/flashcard/flashcard.component.scss
@@ -35,7 +35,7 @@
   }
 
   .arrow {
-    margin-top: 8px;
+    margin-top: 4px;
     grid-column: 1 / 2;
     width: 40px;
     height: 40px;

--- a/src/app/flashcard/flashcard.component.ts
+++ b/src/app/flashcard/flashcard.component.ts
@@ -2,6 +2,7 @@
 import { Component, ContentChild, Input, TemplateRef, HostListener, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import {MatIconModule} from '@angular/material/icon';
+import { FlashcardData } from '../data-models/flashcard-model';
 
 @Component({
   selector: 'app-flashcard',
@@ -16,11 +17,9 @@ export class FlashcardComponent implements OnInit{
   @ContentChild(TemplateRef) addOns!: TemplateRef<any>;
   // Gets a scale factor to resize the component
   @Input() scaleFactor: number = 1;
+  @Input() flashcard: FlashcardData = new FlashcardData('error', 'error');
   height: number = 282 * this.scaleFactor;
   width: number = 500 * this.scaleFactor;
-
-  frontText: string = 'term';
-  backText: string = 'definition';
   isFlipped: boolean = false;
 
   ngOnInit(): void {

--- a/src/app/sequence-card/_sequence-card-theme.scss
+++ b/src/app/sequence-card/_sequence-card-theme.scss
@@ -1,0 +1,31 @@
+@use '@angular/material' as mat;
+@use '@angular/material-experimental' as matx;
+
+@mixin theme($theme) {
+  .add-to-sequence {
+    background-color: mat.get-theme-color($theme, primary);
+    color: mat.get-theme-color($theme, on-primary);
+  }
+
+  .enlarge {
+    color: mat.get-theme-color($theme, on-primary-container);
+  }
+
+  .sequence-card {
+    background-color: mat.get-theme-color($theme, primary-container);
+  }
+
+  .card-term {
+    font: mat.get-theme-typography($theme, display-small);
+    color: mat.get-theme-color($theme, on-primary-container);
+  }
+
+  .remove-from-sequence {
+    background-color: mat.get-theme-color($theme, primary);
+    color: mat.get-theme-color($theme, on-primary);
+  }
+
+  .enlarge-seq-card {
+    color: mat.get-theme-color($theme, on-primary-container);
+  }
+}

--- a/src/app/sequence-card/sequence-card.component.html
+++ b/src/app/sequence-card/sequence-card.component.html
@@ -1,8 +1,8 @@
 <div class="sequence-card" *ngIf="inSequence; else poolCard">
   <div class="card-term">
-    {{term}}
+    {{this.flashcard?.term}}
   </div>
-  <button mat-icon-button class="remove-from-sequence" (click)="removeFromSequence()">
+  <button mat-icon-button class="remove-from-sequence" (click)="removeFromSequence(this.flashcard!, $event)">
     <mat-icon>remove</mat-icon>
   </button>
   <button mat-icon-button class="enlarge-seq-card" (click)="expand($event)">
@@ -10,9 +10,9 @@
   </button>
 </div>
 <ng-template #poolCard class="pool-card">
-  <app-flashcard [scaleFactor]="scaleFactor">
+  <app-flashcard [scaleFactor]="scaleFactor" [flashcard]="flashcard!">
     <ng-template #addOns>
-      <button mat-icon-button class="add-to-sequence" (click)="addToSequence($event)">
+      <button mat-icon-button class="add-to-sequence" (click)="addToSequence(this.flashcard!, $event)">
         <mat-icon>add</mat-icon>
       </button>
       <button mat-icon-button class="enlarge" (click)="expand($event)">

--- a/src/app/sequence-card/sequence-card.component.scss
+++ b/src/app/sequence-card/sequence-card.component.scss
@@ -2,61 +2,50 @@
 @use '@angular/material-experimental' as matx;
 
 
-@mixin theme($theme) {
-  .pool-card {
-    width: 500px;
-    position: relative;
-    margin-left: 100px;
-  }
+.pool-card {
+  width: 500px;
+  position: relative;
+  margin-left: 100px;
+}
 
-  .add-to-sequence {
-    background-color: mat.get-theme-color($theme, primary);
-    color: mat.get-theme-color($theme, on-primary);
-    transform: scale(calc(5 / 3));
-    position: absolute;
-    top: 123px;
-    left: 492px;
-  }
+.add-to-sequence {
+  transform: scale(calc(5 / 3));
+  position: absolute;
+  top: 123px;
+  left: 492px;
+}
 
-  .enlarge {
-    color: mat.get-theme-color($theme, on-primary-container);
-    transform: scale(calc(40/24));
-    position: absolute;
-    bottom: 12px;
-    right: 12px;
-  }
+.enlarge {
+  transform: scale(calc(40/24));
+  position: absolute;
+  bottom: 12px;
+  right: 12px;
+}
 
-  .sequence-card {
-    width: calc(30vw * calc(288 / 404));
-    height: calc(100vh * calc(116 / 720));
-    background-color: mat.get-theme-color($theme, primary-container);
-    box-shadow: 4px 0 8px rgba(0, 0, 0, 0.2), -4px 0 4px rgba(0, 0, 0, 0.2), 0 4px 4px rgba(0, 0, 0, 0.2);
-    border-radius: 12px;
-    display: grid;
-    grid-template-columns: 8% auto 8%;
-    position: relative;
-  }
+.sequence-card {
+  width: calc(30vw * calc(288 / 404));
+  height: calc(100vh * calc(116 / 720));
+  box-shadow: 4px 0 8px rgba(0, 0, 0, 0.2), -4px 0 4px rgba(0, 0, 0, 0.2), 0 4px 4px rgba(0, 0, 0, 0.2);
+  border-radius: 12px;
+  display: grid;
+  grid-template-columns: 8% auto 8%;
+  position: relative;
+}
 
-  .card-term {
-    font: mat.get-theme-typography($theme, display-small);
-    color: mat.get-theme-color($theme, on-primary-container);
-    margin: auto;
-    grid-column: 2;
-  }
+.card-term {
+  margin: auto;
+  grid-column: 2;
+}
 
-  .remove-from-sequence {
-    background-color: mat.get-theme-color($theme, primary);
-    color: mat.get-theme-color($theme, on-primary);
-    transform: scale(calc(2 / 3));
-    position: absolute;
-    left: 0px;
-    bottom: 0px;
-  }
+.remove-from-sequence {
+  transform: scale(calc(2 / 3));
+  position: absolute;
+  left: 0px;
+  bottom: 0px;
+}
 
-  .enlarge-seq-card {
-    color: mat.get-theme-color($theme, on-primary-container);
-    position: absolute;
-    right: 0px;
-    bottom: 0px;
-  }
+.enlarge-seq-card {
+  position: absolute;
+  right: 0px;
+  bottom: 0px;
 }

--- a/src/app/sequence-card/sequence-card.component.ts
+++ b/src/app/sequence-card/sequence-card.component.ts
@@ -1,8 +1,9 @@
-import { Component, HostListener } from '@angular/core';
+import { Component, HostListener, Input, Output, EventEmitter } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FlashcardComponent } from '../flashcard/flashcard.component';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
+import { FlashcardData } from '../data-models/flashcard-model';
 
 @Component({
   selector: 'app-sequence-card',
@@ -12,9 +13,10 @@ import { MatIconModule } from '@angular/material/icon';
   styleUrl: './sequence-card.component.scss'
 })
 export class SequenceCardComponent{
+  @Input() flashcard?: FlashcardData;
+  @Output() addToSeqEvent: EventEmitter<FlashcardData> = new EventEmitter();
+  @Output() removeFromSeqEvent: EventEmitter<FlashcardData> = new EventEmitter();
   scaleFactor: number = window.innerWidth * (220 / 1280) / 500;
-
-  term: string  = "term";
   inSequence: boolean = false;
 
   @HostListener('window:resize', ['$event'])
@@ -22,16 +24,17 @@ export class SequenceCardComponent{
     this.scaleFactor= window.innerWidth * (220 / 1280) / 500;
   }
 
-  addToSequence(e: Event) {
+  addToSequence(flashcard: FlashcardData, e: Event) {
+    this.addToSeqEvent.emit(flashcard);
     e.stopPropagation();
-    this.inSequence = true;
   }
 
   expand(e: Event) {
     e.stopPropagation();
   }
 
-  removeFromSequence() {
-    this.inSequence = false;
+  removeFromSequence(flashcard: FlashcardData, e: Event) {
+    this.addToSeqEvent.emit(flashcard);
+    e.stopPropagation();
   }
 }

--- a/src/app/sequence-card/sequence-card.component.ts
+++ b/src/app/sequence-card/sequence-card.component.ts
@@ -17,7 +17,7 @@ export class SequenceCardComponent{
   @Output() addToSeqEvent: EventEmitter<FlashcardData> = new EventEmitter();
   @Output() removeFromSeqEvent: EventEmitter<FlashcardData> = new EventEmitter();
   scaleFactor: number = window.innerWidth * (220 / 1280) / 500;
-  inSequence: boolean = false;
+  @Input() inSequence: boolean = false;
 
   @HostListener('window:resize', ['$event'])
   onResize(event: Event) {
@@ -34,7 +34,7 @@ export class SequenceCardComponent{
   }
 
   removeFromSequence(flashcard: FlashcardData, e: Event) {
-    this.addToSeqEvent.emit(flashcard);
+    this.removeFromSeqEvent.emit(flashcard);
     e.stopPropagation();
   }
 }

--- a/src/app/sequence-sidebar/sequence-sidebar.component.html
+++ b/src/app/sequence-sidebar/sequence-sidebar.component.html
@@ -1,0 +1,3 @@
+@for (flashcard of userSequence; track userSequence; let i = $index) {
+  <app-sequence-card [flashcard]="flashcard" (removeFromSeqEvent)="removeFromSeq(i)" [inSequence]="true"></app-sequence-card>
+}

--- a/src/app/sequence-sidebar/sequence-sidebar.component.html
+++ b/src/app/sequence-sidebar/sequence-sidebar.component.html
@@ -1,3 +1,3 @@
-@for (flashcard of userSequence; track userSequence; let i = $index) {
-  <app-sequence-card [flashcard]="flashcard" (removeFromSeqEvent)="removeFromSeq(i)" [inSequence]="true"></app-sequence-card>
+@for (item of userSequence; track userSequence; let i = $index) {
+  <app-sequence-card [flashcard]="item.card" (removeFromSeqEvent)="removeFromSeq(item)" [inSequence]="true"></app-sequence-card>
 }

--- a/src/app/sequence-sidebar/sequence-sidebar.component.spec.ts
+++ b/src/app/sequence-sidebar/sequence-sidebar.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SequenceSidebarComponent } from './sequence-sidebar.component';
+
+describe('SequenceSidebarComponent', () => {
+  let component: SequenceSidebarComponent;
+  let fixture: ComponentFixture<SequenceSidebarComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [SequenceSidebarComponent]
+    })
+    .compileComponents();
+    
+    fixture = TestBed.createComponent(SequenceSidebarComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/sequence-sidebar/sequence-sidebar.component.ts
+++ b/src/app/sequence-sidebar/sequence-sidebar.component.ts
@@ -1,6 +1,7 @@
 import { Component, Input, Output, EventEmitter } from '@angular/core';
 import { FlashcardData } from '../data-models/flashcard-model';
 import { SequenceCardComponent } from '../sequence-card/sequence-card.component';
+import { CardMap } from '../study-sequence/study-sequence.component';
 
 @Component({
   selector: 'app-sequence-sidebar',
@@ -10,10 +11,10 @@ import { SequenceCardComponent } from '../sequence-card/sequence-card.component'
   styleUrl: './sequence-sidebar.component.scss'
 })
 export class SequenceSidebarComponent {
-  @Input() userSequence: FlashcardData[] = [];
-  @Output() removeFromSeqEvent: EventEmitter<number> = new EventEmitter<number>;
+  @Input() userSequence: CardMap[] = [];
+  @Output() removeFromSeqEvent: EventEmitter<CardMap> = new EventEmitter<CardMap>;
 
-  removeFromSeq(i: number) {
-    this.removeFromSeqEvent.emit(i);
+  removeFromSeq(item: CardMap) {
+    this.removeFromSeqEvent.emit(item);
   }
 }

--- a/src/app/sequence-sidebar/sequence-sidebar.component.ts
+++ b/src/app/sequence-sidebar/sequence-sidebar.component.ts
@@ -1,5 +1,4 @@
 import { Component, Input, Output, EventEmitter } from '@angular/core';
-import { FlashcardData } from '../data-models/flashcard-model';
 import { SequenceCardComponent } from '../sequence-card/sequence-card.component';
 import { CardMap } from '../study-sequence/study-sequence.component';
 

--- a/src/app/sequence-sidebar/sequence-sidebar.component.ts
+++ b/src/app/sequence-sidebar/sequence-sidebar.component.ts
@@ -1,0 +1,19 @@
+import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { FlashcardData } from '../data-models/flashcard-model';
+import { SequenceCardComponent } from '../sequence-card/sequence-card.component';
+
+@Component({
+  selector: 'app-sequence-sidebar',
+  standalone: true,
+  imports: [SequenceCardComponent],
+  templateUrl: './sequence-sidebar.component.html',
+  styleUrl: './sequence-sidebar.component.scss'
+})
+export class SequenceSidebarComponent {
+  @Input() userSequence: FlashcardData[] = [];
+  @Output() removeFromSeqEvent: EventEmitter<number> = new EventEmitter<number>;
+
+  removeFromSeq(i: number) {
+    this.removeFromSeqEvent.emit(i);
+  }
+}

--- a/src/app/study-sequence/study-sequence.component.html
+++ b/src/app/study-sequence/study-sequence.component.html
@@ -3,7 +3,7 @@
     <app-return-ribbon></app-return-ribbon>
   </div>
   <div class="card-pool">
-    <app-card-pool (addToSeqEvent)="addToSeq($event)" [visUpdates]="visUpdates.asObservable()"></app-card-pool>
+    <app-card-pool [cardPool]="cardPool" (addToSeqEvent)="addToSeq($event)" [visUpdates]="visUpdates.asObservable()"></app-card-pool>
   </div>
   <div class="sequence-select">
     <h2>Sequence select</h2>

--- a/src/app/study-sequence/study-sequence.component.html
+++ b/src/app/study-sequence/study-sequence.component.html
@@ -4,8 +4,9 @@
   </div>
   <div class="card-pool">
     <h2>Card pool</h2>
-    <app-sequence-card></app-sequence-card>
-    <app-sequence-card></app-sequence-card>
+    <app-card-pool></app-card-pool>
+    <!-- <app-sequence-card></app-sequence-card>
+    <app-sequence-card></app-sequence-card> -->
   </div>
   <div class="sequence-select">
     <h2>Sequence select</h2>

--- a/src/app/study-sequence/study-sequence.component.html
+++ b/src/app/study-sequence/study-sequence.component.html
@@ -3,10 +3,7 @@
     <app-return-ribbon></app-return-ribbon>
   </div>
   <div class="card-pool">
-    <h2>Card pool</h2>
-    <app-card-pool></app-card-pool>
-    <!-- <app-sequence-card></app-sequence-card>
-    <app-sequence-card></app-sequence-card> -->
+    <app-card-pool (addToSeqEvent)="addToSeq($event)" [visUpdates]="visUpdates.asObservable()"></app-card-pool>
   </div>
   <div class="sequence-select">
     <h2>Sequence select</h2>
@@ -14,6 +11,7 @@
   <div class="sequence-builder">
     <div class="cards-in-sequence">
         <h2>Cards in Sequence</h2>
+        <app-sequence-sidebar [userSequence]="userSeq" (removeFromSeqEvent)="removeFromSequence($event)"></app-sequence-sidebar>
     </div>
     <div class="check-show-answer">
         <h2>Check/showAnswer</h2>

--- a/src/app/study-sequence/study-sequence.component.html
+++ b/src/app/study-sequence/study-sequence.component.html
@@ -2,16 +2,19 @@
   <div class="back-to-view">
     <app-return-ribbon></app-return-ribbon>
   </div>
-  <div class="card-pool">
-    <app-card-pool [cardPool]="cardPool" (addToSeqEvent)="addToSeq($event)" [visUpdates]="visUpdates.asObservable()"></app-card-pool>
-  </div>
+  <app-card-pool [cardPool]="cardPool"
+    [visUpdates]="visUpdates.asObservable()"
+    (addToSeqEvent)="addToSeq($event)">
+  </app-card-pool>
   <div class="sequence-select">
     <h2>Sequence select</h2>
   </div>
   <div class="sequence-builder">
     <div class="cards-in-sequence">
-        <h2>Cards in Sequence</h2>
-        <app-sequence-sidebar [userSequence]="userSeq" (removeFromSeqEvent)="removeFromSequence($event)"></app-sequence-sidebar>
+      <h2>Cards in Sequence</h2>
+      <app-sequence-sidebar [userSequence]="userSeq"
+        (removeFromSeqEvent)="removeFromSequence($event)">
+      </app-sequence-sidebar>
     </div>
     <div class="check-show-answer">
         <h2>Check/showAnswer</h2>

--- a/src/app/study-sequence/study-sequence.component.html
+++ b/src/app/study-sequence/study-sequence.component.html
@@ -2,10 +2,12 @@
   <div class="back-to-view">
     <app-return-ribbon></app-return-ribbon>
   </div>
-  <app-card-pool [cardPool]="cardPool"
-    [visUpdates]="visUpdates.asObservable()"
-    (addToSeqEvent)="addToSeq($event)">
-  </app-card-pool>
+  <div id="card-pool">
+    <app-card-pool [cardPool]="cardPool"
+      [visUpdates]="visUpdates.asObservable()"
+      (addToSeqEvent)="addToSeq($event)">
+    </app-card-pool>
+  </div>
   <div class="sequence-select">
     <h2>Sequence select</h2>
   </div>

--- a/src/app/study-sequence/study-sequence.component.scss
+++ b/src/app/study-sequence/study-sequence.component.scss
@@ -13,13 +13,6 @@
     height: calc(100vh - 56px);
 }
 
-.card-pool{
-    outline: 1px solid blue;
-    grid-column-start: 1;
-    grid-column-end: 3;
-    text-align: center;
-}
-
 .sequence-builder{
     outline: 1px dashed magenta;
     grid-column-start: 3;

--- a/src/app/study-sequence/study-sequence.component.scss
+++ b/src/app/study-sequence/study-sequence.component.scss
@@ -1,11 +1,11 @@
-.back-to-view{
+.back-to-view {
     outline: 1px dashed black;
     grid-column-start: 1;
     grid-column-end: 3;
     grid-row-end: 2;
 }
 
-.container{
+.container {
     display: grid;
     //Makes a grid with 3 columns
     grid-template-columns: auto auto 30%;
@@ -13,7 +13,7 @@
     height: calc(100vh - 56px);
 }
 
-.sequence-builder{
+.sequence-builder {
     outline: 1px dashed magenta;
     grid-column-start: 3;
     grid-column-end: 4;
@@ -21,20 +21,27 @@
     grid-template-rows: auto auto auto;
 }
 
-.sequence-select{
+.sequence-select {
     outline: 1px dashed green;
     text-align: center;
     grid-column-start: 3;
     grid-row-start: 1;
 }
 
-.cards-in-sequence{
+.cards-in-sequence {
     outline: 1px dashed purple;
     height: calc(100vh - 200px);
     text-align: center;
 }
 
-.check-show-answer{
+.check-show-answer {
     outline: 1px dashed yellow;
     text-align: center;
+}
+
+#card-pool {
+  width: 100%;
+  overflow-y: scroll;
+  grid-column-start: 1;
+  grid-column-end: 3;
 }

--- a/src/app/study-sequence/study-sequence.component.ts
+++ b/src/app/study-sequence/study-sequence.component.ts
@@ -5,29 +5,39 @@ import { ReturnRibbonComponent } from '../return-ribbon/return-ribbon.component'
 import { CardPoolComponent } from '../card-pool/card-pool.component';
 import { SequenceData } from '../data-models/sequence-model';
 import { FlashcardData } from '../data-models/flashcard-model';
+import { SequenceSidebarComponent } from '../sequence-sidebar/sequence-sidebar.component';
+import { Observable, Subject } from 'rxjs';
 
 @Component({
   selector: 'app-study-sequence',
   standalone: true,
-  imports: [SequenceCardComponent, FlashcardComponent, ReturnRibbonComponent, CardPoolComponent],
+  imports: [
+    SequenceCardComponent,
+    FlashcardComponent,
+    ReturnRibbonComponent,
+    CardPoolComponent,
+    SequenceSidebarComponent
+  ],
   templateUrl: './study-sequence.component.html',
   styleUrl: './study-sequence.component.scss'
 })
 export class StudySequenceComponent {
   selectedSeq?: SequenceData;
-  cardInSeq: FlashcardData[] = [];
+  userSeq: FlashcardData[] = [];
   cardPool: FlashcardData[] = [];
+  visUpdates: Subject<string> = new Subject<string>;
 
   addToSeq(flashcard: FlashcardData, index?: number) {
     if (index) {
-      this.cardInSeq.splice(index, 0, flashcard);
+      this.userSeq.splice(index, 0, flashcard);
     } else {
-      this.cardInSeq.push(flashcard);
+      this.userSeq.push(flashcard);
     }
   }
 
-  // needs index to handle duplicate card in user sequence
+  // index is used to handle dupili
   removeFromSequence(index: number) {
-    this.cardInSeq.splice(index, 1);
+    this.visUpdates.next(this.userSeq[index].term)
+    this.userSeq.splice(index, 1);
   }
 }

--- a/src/app/study-sequence/study-sequence.component.ts
+++ b/src/app/study-sequence/study-sequence.component.ts
@@ -2,14 +2,32 @@ import { Component } from '@angular/core';
 import { SequenceCardComponent } from '../sequence-card/sequence-card.component';
 import { FlashcardComponent } from '../flashcard/flashcard.component';
 import { ReturnRibbonComponent } from '../return-ribbon/return-ribbon.component';
+import { CardPoolComponent } from '../card-pool/card-pool.component';
+import { SequenceData } from '../data-models/sequence-model';
+import { FlashcardData } from '../data-models/flashcard-model';
 
 @Component({
   selector: 'app-study-sequence',
   standalone: true,
-  imports: [SequenceCardComponent, FlashcardComponent, ReturnRibbonComponent],
+  imports: [SequenceCardComponent, FlashcardComponent, ReturnRibbonComponent, CardPoolComponent],
   templateUrl: './study-sequence.component.html',
   styleUrl: './study-sequence.component.scss'
 })
 export class StudySequenceComponent {
+  selectedSeq?: SequenceData;
+  cardInSeq: FlashcardData[] = [];
+  cardPool: FlashcardData[] = [];
 
+  addToSeq(flashcard: FlashcardData, index?: number) {
+    if (index) {
+      this.cardInSeq.splice(index, 0, flashcard);
+    } else {
+      this.cardInSeq.push(flashcard);
+    }
+  }
+
+  // needs index to handle duplicate card in user sequence
+  removeFromSequence(index: number) {
+    this.cardInSeq.splice(index, 1);
+  }
 }

--- a/src/app/study-sequence/study-sequence.component.ts
+++ b/src/app/study-sequence/study-sequence.component.ts
@@ -53,24 +53,23 @@ export class StudySequenceComponent {
 
   // index is used to handle
   removeFromSequence(item: CardMap) {
-    this.visUpdates.next(item)
+    this.visUpdates.next(item);
     const index = this.userSeq.indexOf(item);
     this.userSeq.splice(index, 1);
   }
 
   generateCardPool() {
-    const seqLen = this.selectedSeq.cardList.length
+    const seqLen = this.selectedSeq.cardList.length;
     const pool = Array<CardMap>(seqLen);
 
     // copy sequence cards into pool
     this.selectedSeq.cardList.forEach((flashcard, index) => {
-      pool[index] = {key: index, card: flashcard}
-      }
-    )
+      pool[index] = {key: index, card: flashcard};
+    })
 
     // get cards not in th sequence
     const otherCards = this.studySet!.getCardsNotInSeq(this.selectedSeq);
-    if (otherCards.length > 3) { this.shuffle(otherCards)}
+    if (otherCards.length > 3) { this.shuffle(otherCards)};
 
     // add up to 3 distraction cards
     while(pool.length <= seqLen + 3 && otherCards.length > 0) {

--- a/src/app/study-sequence/study-sequence.component.ts
+++ b/src/app/study-sequence/study-sequence.component.ts
@@ -6,7 +6,14 @@ import { CardPoolComponent } from '../card-pool/card-pool.component';
 import { SequenceData } from '../data-models/sequence-model';
 import { FlashcardData } from '../data-models/flashcard-model';
 import { SequenceSidebarComponent } from '../sequence-sidebar/sequence-sidebar.component';
-import { Observable, Subject } from 'rxjs';
+import { Subject } from 'rxjs';
+import { StudySetData } from '../data-models/studyset-model';
+import { StudySetService } from '../services/study-set.service';
+
+export interface CardMap {
+  key: number,
+  card: FlashcardData
+}
 
 @Component({
   selector: 'app-study-sequence',
@@ -22,22 +29,63 @@ import { Observable, Subject } from 'rxjs';
   styleUrl: './study-sequence.component.scss'
 })
 export class StudySequenceComponent {
-  selectedSeq?: SequenceData;
-  userSeq: FlashcardData[] = [];
-  cardPool: FlashcardData[] = [];
-  visUpdates: Subject<string> = new Subject<string>;
+  studySet?: StudySetData;
+  selectedSeq: SequenceData = new SequenceData();
+  userSeq: CardMap[] = [];
+  cardPool: CardMap[] = [];
+  visUpdates: Subject<CardMap> = new Subject<CardMap>();
 
-  addToSeq(flashcard: FlashcardData, index?: number) {
-    if (index) {
-      this.userSeq.splice(index, 0, flashcard);
-    } else {
-      this.userSeq.push(flashcard);
-    }
+  constructor(private studySetService: StudySetService) {}
+
+  ngOnInit() {
+    this.studySetService.getStudySet('aaaa')
+      .subscribe(sSet => [
+        this.studySet = sSet,
+        this.selectedSeq = this.studySet!.sequences[0],
+        console.log(this.studySet),
+        this.generateCardPool(),
+      ]);
   }
 
-  // index is used to handle dupili
-  removeFromSequence(index: number) {
-    this.visUpdates.next(this.userSeq[index].term)
+  addToSeq(item: CardMap) {
+    this.userSeq.push(item);
+  }
+
+  // index is used to handle
+  removeFromSequence(item: CardMap) {
+    this.visUpdates.next(item)
+    const index = this.userSeq.indexOf(item);
     this.userSeq.splice(index, 1);
+  }
+
+  generateCardPool() {
+    const seqLen = this.selectedSeq.cardList.length
+    const pool = Array<CardMap>(seqLen);
+
+    // copy sequence cards into pool
+    this.selectedSeq.cardList.forEach((flashcard, index) => {
+      pool[index] = {key: index, card: flashcard}
+      }
+    )
+
+    // get cards not in th sequence
+    const otherCards = this.studySet!.getCardsNotInSeq(this.selectedSeq);
+    if (otherCards.length > 3) { this.shuffle(otherCards)}
+
+    // add up to 3 distraction cards
+    while(pool.length <= seqLen + 3 && otherCards.length > 0) {
+      pool.push({key: pool.length+1, card: otherCards.pop()!});
+    }
+
+    this.shuffle(pool);
+    this.cardPool = pool;
+  }
+
+  // shuffle order using Fisher-Yates
+  shuffle(array: any[]) {
+    for (let i = array.length -1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i+1));
+      [array[i], array[j]] = [array[j], array[i]];
+    }
   }
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -10,7 +10,7 @@
 @use 'app/homepage/homepage.component';
 @use 'app/viewstudyset/viewstudyset.component';
 @use 'app/flashcard/flashcard.component';
-@use 'app/sequence-card/sequence-card.component';
+@use 'app/sequence-card/sequence-card-theme' as seq-card;
 @use 'app/studybuttonmenu/studybuttonmenu.component';
 @use 'app/return-ribbon/return-ribbon.component';
 @use 'app/flashcard-editor/flashcard-editor-theme' as card-editor;
@@ -44,7 +44,7 @@ html {
   @include homepage.theme($theme);
   @include viewstudyset.theme($theme);
   @include flashcard.theme($theme);
-  @include sequence-card.theme($theme);
+  @include seq-card.theme($theme);
   @include studybuttonmenu.theme($theme);
   @include return-ribbon.theme($theme);
   @include card-editor.theme($theme);


### PR DESCRIPTION
fixes #37 
- I created the card pool on the study sequence page and also set up the event propagation to add it to the sequence side bar when the add button is pressed. 
- Dylan will format the side bar in #38, but I just wanted to show that clicks do move things around
- Adding dragging and other functionality of the card pool will be added in #42 
  - something to note, the flashcards in the card pool flip. Its really hard to make cards flip and drag. I also read it is bad UX design because people with laggy computers might trigger the wrong one. We should decide if we want to disable the flip or drag feature.
- I also didn't fix the font size on the flashcard because I didn't know it was intentionally small
- To test the scroll and duplicate flashcard support, just copy the flashcards in a sequence over and over again in the dev-set-db.json file.
- I also didn't have the card pool rearrange the cards when one card is removed, because it made the UX bad. I think it will be easier for the user to find the card they need if the cards in the card pool don't reposition when a card is moved the sequence side bar.