### PR TITLE
Added set id as query parameter and modified routing

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -8,7 +8,7 @@ import { ViewstudysetComponent } from './viewstudyset/viewstudyset.component';
 
 export const routes: Routes = [
   {
-    path: 'signIn',
+    path: 'sign-in',
     component: SignInComponent,
     title:'Sign In Page'
   },
@@ -18,23 +18,28 @@ export const routes: Routes = [
     title:'Edit Create Study Set Page'
   },
   {
-    path: 'homepage',
+    path: 'home-page',
     component: HomepageComponent,
     title: 'Home Page'
   },
   {
-    path: 'studyFlashcard',
+    path: 'study-flashcard',
     component: StudyFlashcardComponent,
     title:'Study Flashcard Page'
   },
   {
-    path: 'studySequence',
+    path: 'study-sequence',
     component: StudySequenceComponent,
     title:'Study Sequence Page'
   },
   {
-    path: 'viewStudySet',
+    path: 'view-set',
     component: ViewstudysetComponent,
     title:'View Study Set Page'
   },
+  {
+    path: '',
+    redirectTo:'/home-page',
+    pathMatch: 'full'
+  }
 ];

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,17 +1,11 @@
 import { Routes } from '@angular/router';
 import { EditCreateStudySetComponent } from './edit-create-study-set/edit-create-study-set.component';
 import { HomepageComponent } from './homepage/homepage.component';
-import { SignInComponent } from './sign-in/sign-in.component';
 import { StudyFlashcardComponent } from './study-flashcard/study-flashcard.component';
 import { StudySequenceComponent } from './study-sequence/study-sequence.component';
 import { ViewstudysetComponent } from './viewstudyset/viewstudyset.component';
 
 export const routes: Routes = [
-  {
-    path: 'sign-in',
-    component: SignInComponent,
-    title:'Sign In Page'
-  },
   {
     path: 'edit-set',
     component: EditCreateStudySetComponent,

--- a/src/app/edit-create-study-set/edit-create-study-set.component.ts
+++ b/src/app/edit-create-study-set/edit-create-study-set.component.ts
@@ -60,6 +60,10 @@ export class EditCreateStudySetComponent {
   };
 
   ngOnInit() {
+    this.loadStudySet();
+  }
+
+  loadStudySet() {
     getStudySetFromUrl(this.route, this.studySetService)
       .subscribe({
         next: (sSet) => [

--- a/src/app/edit-create-study-set/edit-create-study-set.component.ts
+++ b/src/app/edit-create-study-set/edit-create-study-set.component.ts
@@ -14,6 +14,8 @@ import { MatDialog, MatDialogModule } from '@angular/material/dialog';
 import { SavePopUpComponent } from '../save-pop-up/save-pop-up.component';
 import { FlashcardData } from '../data-models/flashcard-model';
 import { SequenceData } from '../data-models/sequence-model';
+import { getStudySetFromUrl } from '../utilities/route-helper';
+import { RouteParamNotFound } from '../errors/route-param-error';
 
 @Component({
   selector: 'app-edit-create-study-set',
@@ -58,27 +60,19 @@ export class EditCreateStudySetComponent {
   };
 
   ngOnInit() {
-    this.route.queryParamMap.subscribe(params => {
-      const uid = params.get("uid");
-      if (uid) {
-        this.userId = uid;
-      }
-      const sid = params.get("sid");
-      if (sid) {
-        this.getStudySet(sid);
-      } else {
-        this.studySet.addCard();
-        this.isLoaded = true;
-      }
-    });
-  }
-
-  getStudySet(setId: string) {
-    this.studySetService.getStudySet(setId)
-      .subscribe(sSet => [
-        this.studySet = sSet,
-        this.isLoaded = true
-      ]);
+    getStudySetFromUrl(this.route, this.studySetService)
+      .subscribe({
+        next: (sSet) => [
+          this.studySet = sSet,
+          this.isLoaded = true
+        ],
+        error: (e) => {if (e instanceof RouteParamNotFound) {
+          this.studySet.addCard();
+          this.isLoaded = true;
+        } else {
+          console.log(e);
+        }}
+      });
   }
 
   saveSet() {
@@ -94,6 +88,7 @@ export class EditCreateStudySetComponent {
   addCard() {
     this.studySet.addCard();
   }
+
   addSequence() {
     this.studySet.addSequence("default");
   }
@@ -101,6 +96,7 @@ export class EditCreateStudySetComponent {
   removeCard(flashcard: FlashcardData) {
     this.studySet.deleteCard(flashcard);
   }
+
   removeSequence(seq: SequenceData) {
     this.studySet.deleteSequence(seq);
   }

--- a/src/app/edit-create-study-set/edit-create-study-set.component.ts
+++ b/src/app/edit-create-study-set/edit-create-study-set.component.ts
@@ -84,20 +84,20 @@ export class EditCreateStudySetComponent {
   saveSet() {
     if (this.studySet.isValid()) {
       this.studySetService.saveStudySet(this.studySet).subscribe(newId => [
-        this.router.navigate(["viewStudySet"], { queryParams:{ sid: newId }})
+        this.router.navigate(["view-set"], { queryParams:{ sid: newId }})
       ]);
     } else {
       this.dialogRef.open(SavePopUpComponent);
     }
   }
-  
+
   addCard() {
     this.studySet.addCard();
   }
   addSequence() {
     this.studySet.addSequence("default");
   }
-  
+
   removeCard(flashcard: FlashcardData) {
     this.studySet.deleteCard(flashcard);
   }

--- a/src/app/errors/route-param-error.ts
+++ b/src/app/errors/route-param-error.ts
@@ -1,0 +1,6 @@
+export class RouteParamNotFound extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "RouteParamNotFound";
+  }
+}

--- a/src/app/navbar/navbar.component.html
+++ b/src/app/navbar/navbar.component.html
@@ -11,7 +11,7 @@
         <li><button mat-icon-button aria-label="Create Set Button with a plus icon" class="circle-button" [routerLink]="['edit-set']">
           <mat-icon class="symbol">add</mat-icon>
         </button></li>
-        <li><button mat-icon-button aria-label="Logout Button with a exit door icon" class="circle-button" [routerLink]="['sign-in']" (click)="this.signOut.emit()">
+        <li><button mat-icon-button aria-label="Logout Button with a exit door icon" class="circle-button" (click)="this.signOut.emit()">
           <mat-icon class="symbol">logout</mat-icon>
         </button></li>
       </ul>

--- a/src/app/navbar/navbar.component.html
+++ b/src/app/navbar/navbar.component.html
@@ -1,6 +1,6 @@
 <header>
   <div class="container" *ngIf="signedIn; else elseBlock">
-    <a class="ponder-name" routerLink="homepage">Ponder</a>
+    <a class="ponder-name" routerLink="home-page">Ponder</a>
 
     <div class="search-bar">
       put search bar component here
@@ -11,7 +11,7 @@
         <li><button mat-icon-button aria-label="Create Set Button with a plus icon" class="circle-button" [routerLink]="['edit-set']">
           <mat-icon class="symbol">add</mat-icon>
         </button></li>
-        <li><button mat-icon-button aria-label="Logout Button with a exit door icon" class="circle-button" [routerLink]="['signIn']" (click)="this.signOut.emit()">
+        <li><button mat-icon-button aria-label="Logout Button with a exit door icon" class="circle-button" [routerLink]="['sign-in']" (click)="this.signOut.emit()">
           <mat-icon class="symbol">logout</mat-icon>
         </button></li>
       </ul>

--- a/src/app/return-ribbon/return-ribbon.component.html
+++ b/src/app/return-ribbon/return-ribbon.component.html
@@ -1,5 +1,5 @@
 <div class="return-ribbon">
-  <div class="clickable" [routerLink]="['/viewStudySet']">
+  <div class="clickable" [routerLink]="['/view-set']" [queryParams]="{sid: setId}">
     <mat-icon aria-hidden="false" aria-label="Back arrow">arrow_back</mat-icon>
     <h1 class="set-name">Flashcard Set Name</h1>
   </div>

--- a/src/app/return-ribbon/return-ribbon.component.ts
+++ b/src/app/return-ribbon/return-ribbon.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, Input } from '@angular/core';
 import { MatIconModule } from '@angular/material/icon';
 import { RouterModule, RouterLink } from '@angular/router';
 
@@ -10,5 +10,5 @@ import { RouterModule, RouterLink } from '@angular/router';
   styleUrl: './return-ribbon.component.scss'
 })
 export class ReturnRibbonComponent {
-
+  @Input() setId?: string = "";
 }

--- a/src/app/set-preview-card/set-preview-card.component.html
+++ b/src/app/set-preview-card/set-preview-card.component.html
@@ -1,4 +1,4 @@
-<mat-card class="study-set-card" [routerLink]="['/viewStudySet']">
+<mat-card class="study-set-card" [routerLink]="['/view-set']" [queryParams]="{sid: setId}">
   <!-- fix routing when other components are finished -->
   <mat-card-title class="study-set-title">{{studySet.title}}</mat-card-title>
   <div class="study-set-badge-row">

--- a/src/app/sign-in/sign-in.component.html
+++ b/src/app/sign-in/sign-in.component.html
@@ -1,7 +1,7 @@
 <section>
   <button class = "sign-in"
     (click)="this.signIn.emit(true)"
-    [routerLink]="['/homepage']">
+    [routerLink]="['/home-page']">
     Sign In with Google. Placeholder.
   </button>
 </section>

--- a/src/app/sign-in/sign-in.component.html
+++ b/src/app/sign-in/sign-in.component.html
@@ -1,7 +1,5 @@
 <section>
-  <button class = "sign-in"
-    (click)="this.signIn.emit(true)"
-    [routerLink]="['/home-page']">
+  <button class = "sign-in" (click)="this.signIn.emit(true)">
     Sign In with Google. Placeholder.
   </button>
 </section>

--- a/src/app/study-flashcard/study-flashcard.component.html
+++ b/src/app/study-flashcard/study-flashcard.component.html
@@ -1,7 +1,7 @@
 <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 
 <div class="back-to-view">
-  <app-return-ribbon></app-return-ribbon>
+  <app-return-ribbon [setId]="'aaaa'"></app-return-ribbon>
 </div>
 
 <div class="card-space">

--- a/src/app/study-flashcard/study-flashcard.component.html
+++ b/src/app/study-flashcard/study-flashcard.component.html
@@ -1,7 +1,7 @@
 <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 
 <div class="back-to-view">
-  <app-return-ribbon [setId]="'aaaa'"></app-return-ribbon>
+  <app-return-ribbon [setId]="setId"></app-return-ribbon>
 </div>
 
 <div class="card-space">
@@ -12,7 +12,7 @@
   </div>
   <app-flashcard class="flashcard-study"
     [scaleFactor]="cardScaleFactor"
-    [flashcard]="currentFlashcard">
+    [flashcard]="currentFlashcard!">
   </app-flashcard>
   <div class="arrow-button-next"
     [class.hide]="!hasNextCard()"

--- a/src/app/study-flashcard/study-flashcard.component.ts
+++ b/src/app/study-flashcard/study-flashcard.component.ts
@@ -40,12 +40,16 @@ export class StudyFlashcardComponent {
   }
 
   ngOnInit() {
+    this.loadFlashcards();
+  }
+
+  loadFlashcards() {
     getStudySetFromUrl(this.route, this.studySetService)
       .subscribe(sSet => [
         this.flashcards = sSet.flashcards,
         this.setId = sSet.id,
         this.currentFlashcard = this.flashcards[this.currentCardIndex]
-    ]);
+      ]);
   }
 
   previousFlashcard() {

--- a/src/app/study-flashcard/study-flashcard.component.ts
+++ b/src/app/study-flashcard/study-flashcard.component.ts
@@ -5,6 +5,8 @@ import { StudySetService } from '../services/study-set.service';
 import { FlashcardData } from '../data-models/flashcard-model';
 import { CommonModule } from '@angular/common';
 import { MatIcon } from '@angular/material/icon';
+import { getStudySetFromUrl } from '../utilities/route-helper';
+import { ActivatedRoute } from '@angular/router';
 
 @Component({
   selector: 'app-study-flashcard',
@@ -21,12 +23,16 @@ import { MatIcon } from '@angular/material/icon';
 export class StudyFlashcardComponent {
   /** Constant used for calculating flashcard scale */
   private readonly scaleFactorConstant = (496 / 720) / 282;
-  constructor(private studySetService: StudySetService) { }
-
   cardScaleFactor: number = window.innerHeight * this.scaleFactorConstant;
   flashcards: FlashcardData[] = [];
   currentFlashcard: FlashcardData = new FlashcardData();
   currentCardIndex: number = 0;
+  setId?: string;
+
+  constructor(
+    private studySetService: StudySetService,
+    private route: ActivatedRoute
+  ) { }
 
   @HostListener('window:resize', ['$event'])
   onResize(event: Event) {
@@ -34,12 +40,12 @@ export class StudyFlashcardComponent {
   }
 
   ngOnInit() {
-    this.studySetService.getStudySet("aaaa")
-      .subscribe(studySet => {
-         this.flashcards = studySet.flashcards;
-         this.currentFlashcard =  this.flashcards[0];
-      }
-    );
+    getStudySetFromUrl(this.route, this.studySetService)
+      .subscribe(sSet => [
+        this.flashcards = sSet.flashcards,
+        this.setId = sSet.id,
+        this.currentFlashcard = this.flashcards[this.currentCardIndex]
+    ]);
   }
 
   previousFlashcard() {

--- a/src/app/study-sequence/study-sequence.component.html
+++ b/src/app/study-sequence/study-sequence.component.html
@@ -1,6 +1,6 @@
 <div class="container">
   <div class="back-to-view">
-    <app-return-ribbon></app-return-ribbon>
+    <app-return-ribbon [setId]="studySet?.id"></app-return-ribbon>
   </div>
   <div id="card-pool">
     <app-card-pool [cardPool]="cardPool"

--- a/src/app/study-sequence/study-sequence.component.ts
+++ b/src/app/study-sequence/study-sequence.component.ts
@@ -53,7 +53,6 @@ export class StudySequenceComponent {
       .subscribe(sSet => [
         this.studySet = sSet,
         this.selectedSeq = this.studySet!.sequences[0],
-        console.log(this.studySet),
         this.generateCardPool(),
       ]);
   }

--- a/src/app/study-sequence/study-sequence.component.ts
+++ b/src/app/study-sequence/study-sequence.component.ts
@@ -14,6 +14,8 @@ import { SequenceSidebarComponent } from '../sequence-sidebar/sequence-sidebar.c
 import { Subject } from 'rxjs';
 import { StudySetData } from '../data-models/studyset-model';
 import { StudySetService } from '../services/study-set.service';
+import { getStudySetFromUrl } from '../utilities/route-helper';
+import { ActivatedRoute } from '@angular/router';
 
 export interface CardMap {
   key: number,
@@ -46,15 +48,23 @@ export class StudySequenceComponent {
   cardPool: CardMap[] = [];
   visUpdates: Subject<CardMap> = new Subject<CardMap>();
 
-  constructor(private studySetService: StudySetService) {}
+  constructor(
+    private studySetService: StudySetService,
+    private route: ActivatedRoute
+  ) {}
 
   ngOnInit() {
-    this.studySetService.getStudySet('bbbb')
+    this.loadStudySet();
+  }
+
+  loadStudySet() {
+    getStudySetFromUrl(this.route, this.studySetService)
       .subscribe(sSet => [
         this.studySet = sSet,
-        this.selectedSeq = this.studySet!.sequences[0],
-        this.generateCardPool(),
-      ]);
+        this.sequences = sSet.sequences,
+        this.selectedSeq = this.sequences[0],
+        this.generateCardPool()
+    ]);
   }
 
   addToSeq(item: CardMap) {
@@ -100,5 +110,6 @@ export class StudySequenceComponent {
 
   changeSelectedSequence(sequence: SequenceData){
     this.selectedSeq = sequence;
+    this.generateCardPool();
   }
 }

--- a/src/app/studybuttonmenu/studybuttonmenu.component.html
+++ b/src/app/studybuttonmenu/studybuttonmenu.component.html
@@ -2,6 +2,14 @@
   <mat-icon>arrow_drop_down</mat-icon> Study
 </button>
 <mat-menu #menu="matMenu">
-  <button mat-menu-item [routerLink]="['/studyFlashcard']">Flashcard</button>
-  <button mat-menu-item [routerLink]="['/studySequence']">Sequence</button>
+  <button mat-menu-item
+    [routerLink]="['/study-flashcard']"
+    [queryParams]="{sid: setId}">
+    Flashcard
+  </button>
+  <button mat-menu-item
+    [routerLink]="['/study-sequence']"
+    [queryParams]="{sid: setId}">
+    Sequence
+  </button>
 </mat-menu>

--- a/src/app/studybuttonmenu/studybuttonmenu.component.ts
+++ b/src/app/studybuttonmenu/studybuttonmenu.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, Input } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatMenuModule } from '@angular/material/menu';
@@ -13,5 +13,5 @@ import { RouterLink } from '@angular/router';
   styleUrl: './studybuttonmenu.component.scss'
 })
 export class StudybuttonmenuComponent {
-
+  @Input() setId?: string;
 }

--- a/src/app/user-set-card/user-set-card.component.html
+++ b/src/app/user-set-card/user-set-card.component.html
@@ -1,4 +1,4 @@
-<mat-card class = user-sets-card [routerLink]="['/viewStudySet']">
+<mat-card class = user-sets-card [routerLink]="['/view-set']" [queryParams]="{sid: setId}">
   <mat-card-title>{{studySet.title}}</mat-card-title>
   <div class="study-set-badge">{{studySet.flashcards.length}} Terms</div>
   <div class="study-set-badge">{{studySet.sequences.length}} Sequences</div>

--- a/src/app/utilities/route-helper.ts
+++ b/src/app/utilities/route-helper.ts
@@ -1,0 +1,16 @@
+import { ActivatedRoute } from "@angular/router";
+import { StudySetService } from "../services/study-set.service";
+import { map, mergeMap } from 'rxjs/operators';
+
+export function getStudySetFromUrl(route: ActivatedRoute, service: StudySetService) {
+  return route.queryParamMap.pipe(mergeMap(params => {
+    const sid = params.get("sid");
+    if (sid) {
+      return service.getStudySet(sid).pipe(map(sSet => sSet));
+    } else {
+      // we will want to make a 404 not found page
+      console.log("Set does not exist so retrieved default");
+      return service.getStudySet("aaaa").pipe(map(sSet => sSet));
+    }
+  }));
+}

--- a/src/app/utilities/route-helper.ts
+++ b/src/app/utilities/route-helper.ts
@@ -1,16 +1,14 @@
 import { ActivatedRoute } from "@angular/router";
 import { StudySetService } from "../services/study-set.service";
 import { map, mergeMap } from 'rxjs/operators';
+import { RouteParamNotFound } from "../errors/route-param-error";
 
 export function getStudySetFromUrl(route: ActivatedRoute, service: StudySetService) {
   return route.queryParamMap.pipe(mergeMap(params => {
     const sid = params.get("sid");
     if (sid) {
       return service.getStudySet(sid).pipe(map(sSet => sSet));
-    } else {
-      // we will want to make a 404 not found page
-      console.log("Set does not exist so retrieved default");
-      return service.getStudySet("aaaa").pipe(map(sSet => sSet));
     }
+    throw new RouteParamNotFound("sid not found");
   }));
 }

--- a/src/app/viewstudyset/viewstudyset.component.html
+++ b/src/app/viewstudyset/viewstudyset.component.html
@@ -1,10 +1,10 @@
 <div id="title-header" class="view-header">
   <h1>{{studySet.title}}</h1>
-  <button mat-flat-button class="view-button button" [routerLink]="['/edit-set']" [queryParams]="{sid: 'aaaa'}">
+  <button mat-flat-button class="view-button button" [routerLink]="['/edit-set']" [queryParams]="{sid: studySet.id}">
     <mat-icon>mode_edit</mat-icon>
     Edit
   </button>
-  <app-studybuttonmenu class="study-button"></app-studybuttonmenu>
+  <app-studybuttonmenu class="study-button" [setId]="studySet.id"></app-studybuttonmenu>
   <button mat-flat-button class="view-button button" (click)="shareSet()">
     <mat-icon>share</mat-icon>
     Share

--- a/src/app/viewstudyset/viewstudyset.component.ts
+++ b/src/app/viewstudyset/viewstudyset.component.ts
@@ -39,9 +39,13 @@ export class ViewstudysetComponent {
   ) {}
 
   ngOnInit() {
+    this.loadStudySet();
+  }
+
+  loadStudySet() {
     getStudySetFromUrl(this.route, this.studySetService)
       .subscribe(sSet => this.studySet = sSet);
-  };
+  }
 
   ngAfterViewChecked() {
     this.setScrollContainerHeight();

--- a/src/app/viewstudyset/viewstudyset.component.ts
+++ b/src/app/viewstudyset/viewstudyset.component.ts
@@ -12,6 +12,7 @@ import { MatDialog } from '@angular/material/dialog';
 import { SharePopUpComponent } from '../share-pop-up/share-pop-up.component';
 import $ from "jquery";
 import { FlashcardData } from '../data-models/flashcard-model';
+import { getStudySetFromUrl } from '../utilities/route-helper';
 
 @Component({
   selector: 'app-viewstudyset',
@@ -38,27 +39,12 @@ export class ViewstudysetComponent {
   ) {}
 
   ngOnInit() {
-    this.route.queryParamMap.subscribe(params => {
-      const sid = params.get("sid");
-      if (sid) {
-        this.getStudySet(sid);
-      } else {
-        // we will want to make a 404 not found page
-        console.log("Set does not exist so retrieved default");
-        this.getStudySet("aaaa");
-      }
-    })
+    getStudySetFromUrl(this.route, this.studySetService)
+      .subscribe(sSet => this.studySet = sSet);
   };
 
   ngAfterViewChecked() {
     this.setScrollContainerHeight();
-  }
-
-  getStudySet(setId: string) {
-    this.studySetService.getStudySet(setId)
-      .subscribe(sSet => [
-        this.studySet = sSet,
-      ]);
   }
 
   shareSet() {


### PR DESCRIPTION
fixes #103 

- Pages now load study set information using the set id in the url.
- Route naming changed to match kebab convention/best practice
- Sign-in is no longer it's own route and just navigates back to the page the user was originally viewing