### PR TITLE
hot fixes to study set firebase service

### DIFF
--- a/src/app/data-models/flashcard-model.ts
+++ b/src/app/data-models/flashcard-model.ts
@@ -2,7 +2,7 @@ export interface FlashcardModel {
   readonly id: number;
   term: string;
   definition: string;
-  image?: URL;
+  image: string;
   /**
    * Checks if the flashcard is valid. Valid flashcards cannot have an empty
    * term nor definition;
@@ -17,9 +17,9 @@ export class FlashcardData implements FlashcardModel{
   readonly id: number;
   term: string;
   definition: string;
-  image?: URL = undefined;
+  image: string = "";
 
-  constructor(term: string = "", definition: string = "", image?: URL, id: number = -1) {
+  constructor(term: string = "", definition: string = "", image: string = "", id: number = -1) {
     this.term = term.trim();
     this.definition = definition.trim();
     this.image = image;

--- a/src/app/data-models/studyset-model.ts
+++ b/src/app/data-models/studyset-model.ts
@@ -178,7 +178,7 @@ export class StudySetData implements StudySetModel {
   }
 
   /** Create and add a flashcard to the study set. */
-  addCard(term: string = "", definition: string = "", image?: URL): void {
+  addCard(term: string = "", definition: string = "", image: string = ""): void {
     this.flashcards.push(new FlashcardData(term, definition, image, this.nextFid));
     this.incrementNextFid();
   }

--- a/src/app/homepage/homepage.component.ts
+++ b/src/app/homepage/homepage.component.ts
@@ -43,9 +43,10 @@ export class HomepageComponent {
     this.userInfoService.loadUser("Robbie")
       .subscribe(user => [
         this.userInfo = user,
+        this.recentSetList = this.userInfo.getRecentSets(),
+        this.userSetList = this.userInfo.getOwnedSets(),
+        console.log(user)
       ]);
-    this.recentSetList = this.userInfo.getRecentSets();
-    this.userSetList = this.userInfo.getOwnedSets();
   }
 
   @ViewChild('slickModal') slickModal: SlickCarouselComponent = new SlickCarouselComponent;

--- a/src/app/homepage/homepage.component.ts
+++ b/src/app/homepage/homepage.component.ts
@@ -44,8 +44,7 @@ export class HomepageComponent {
       .subscribe(user => [
         this.userInfo = user,
         this.recentSetList = this.userInfo.getRecentSets(),
-        this.userSetList = this.userInfo.getOwnedSets(),
-        console.log(user)
+        this.userSetList = this.userInfo.getOwnedSets()
       ]);
   }
 

--- a/src/app/services/study-set-firebase.service.ts
+++ b/src/app/services/study-set-firebase.service.ts
@@ -18,8 +18,7 @@ export class StudySetFirebaseService extends StudySetService{
   override getStudySet(id: string): Observable<StudySetData> {
     return defer(() => from(getDoc(doc(this.firestore, 'study-sets', id)) as Promise<DocumentSnapshot>))
       .pipe(
-        map((docSnap: DocumentSnapshot) => docSnap.data() as StudySetModel),
-        tap(sSet => sSet.id = id) // reset the id since it wasn't returned
+        map((docSnap: DocumentSnapshot) => docSnap.data() as StudySetModel)
       )
       .pipe(map((dbSet: StudySetModel) => StudySetData.copyStudySet(dbSet)));
   }
@@ -37,7 +36,6 @@ export class StudySetFirebaseService extends StudySetService{
       name: seq.name,
       cardList: seq.cardList.map(card => Object.assign({}, card))
     }))
-    console.log(sequences)
     return defer(() => from(setDoc(docRef, {
       id: docRef.id,
       owner: studySet.owner,
@@ -46,6 +44,6 @@ export class StudySetFirebaseService extends StudySetService{
       flashcards: studySet.flashcards.map(obj => Object.assign({}, obj)),
       sequences: sequences
     }) as Promise<void> ))
-      .pipe(map(() => studySet.id = docRef.id), tap(thingy => thingy));
+      .pipe(map(() => studySet.id = docRef.id));
   }
 }


### PR DESCRIPTION
These are some changes I made because the firebase study set service wasn't working. I don't think I did the cleanest fixes and I open for suggestions. I am just making the PR to facilitate discussion
- URLs are stings and not URL objects to make using the services easier
- Firebase service no longer generates a new id if there is already an id.
- getStudySet sets the id of the returned object now. It was returning an undefined id for some reason