### PR TITLE
32 add card to sequence

### DIFF
--- a/src/app/data-models/sequence-model.ts
+++ b/src/app/data-models/sequence-model.ts
@@ -20,9 +20,16 @@ export interface SequenceModel {
   /**
    * Removes a flashcard from the sequence.
    * @param card card to remove
-   * @returns true is card was found and removed.
+   * @returns true if card was found and removed.
    */
   removeCard(card: FlashcardData): boolean;
+
+  /**
+   * Removes a flashcard from the sequence at the given index
+   * @param index index of card to remove
+   * @returns true if the card was removed.
+   */
+  removeCardAtIndex(index: number): boolean;
 
   /**
    * Moves a card to new position in the sequence and shifts the other cards
@@ -71,6 +78,14 @@ export class SequenceData implements SequenceModel {
     const startLen = this.cardList.length;
     this.cardList = this.cardList.filter(i => i != card);
     return startLen != this.cardList.length;
+  }
+
+  removeCardAtIndex(index: number): boolean {
+    if(index >= 0 && index < this.cardList.length){
+      this.cardList.splice(index, 1);
+      return true;
+    }
+    return false;
   }
 
   reorderCard(card: FlashcardModel, to: number): number {

--- a/src/app/edit-create-study-set/edit-create-study-set.component.html
+++ b/src/app/edit-create-study-set/edit-create-study-set.component.html
@@ -25,7 +25,7 @@
     <div class = "tabs">
       <app-tabs>
         <app-tab-item>
-          <app-tab-label>Flashcards</app-tab-label>
+          <app-tab-label>Flashcards ({{this.studySet.flashcards.length}})</app-tab-label>
           <app-tab-body>
             <app-flashcard-editor
               [flashcards]="studySet.flashcards"
@@ -36,7 +36,7 @@
         </app-tab-item>
 
         <app-tab-item >
-          <app-tab-label>Sequences</app-tab-label>
+          <app-tab-label>Sequences ({{this.studySet.sequences.length}})</app-tab-label>
           <app-tab-body>
             <app-sequence-editor
             [sequences]="studySet.sequences"

--- a/src/app/edit-create-study-set/edit-create-study-set.component.html
+++ b/src/app/edit-create-study-set/edit-create-study-set.component.html
@@ -6,7 +6,7 @@
   <div class="body-div" *ngIf="isLoaded;">
     <div class = "upper-components">
       <div class ="first-row">
-        <h1 class = "page-title">Create Study Set</h1>
+        <h1>Create Study Set</h1>
         <button mat-flat-button class = "done-button" (click)="saveSet()">Done</button>
       </div>
 

--- a/src/app/edit-create-study-set/edit-create-study-set.component.scss
+++ b/src/app/edit-create-study-set/edit-create-study-set.component.scss
@@ -3,10 +3,6 @@
   vertical-align: baseline;
 }
 
-.page-title {
-  padding-left: 3%;
-}
-
 .first-row {
   display: flex;
   align-items: center;

--- a/src/app/edit-create-study-set/edit-create-study-set.component.ts
+++ b/src/app/edit-create-study-set/edit-create-study-set.component.ts
@@ -94,7 +94,7 @@ export class EditCreateStudySetComponent {
   }
 
   addSequence() {
-    this.studySet.addSequence("default");
+    this.studySet.addSequence("unnamed sequence");
   }
 
   removeCard(flashcard: FlashcardData) {

--- a/src/app/sequence-editor/_sequence-editor-theme.scss
+++ b/src/app/sequence-editor/_sequence-editor-theme.scss
@@ -2,7 +2,7 @@
 @use '@angular/material-experimental' as matx;
 
 @mixin theme($theme) {
-  .sequence-tab-left{
+  .sequence-tab-left {
     grid-column-start: 1;
     grid-column-end: 2;
     border-top-left-radius: 12px;
@@ -16,14 +16,14 @@
     grid-template-rows: 40% 60%;
   }
 
-  .sequence-card-list{
+  .sequence-card-list {
     border-top-left-radius: 12px;
     border-right: 1px solid mat.get-theme-color($theme,outline);
     display: flex;
     flex-flow: column;
   }
 
-  .card-search-bar{
+  .card-search-bar {
     font:mat.get-theme-typography($theme, body-small);
     padding:4px;
     color: mat.get-theme-color($theme,on-surface-variant);
@@ -36,16 +36,18 @@
     padding-left: 8px;
   }
 
-  .card-list li{
+  .card-list li {
     font: mat.get-theme-typography($theme, label-large);
     font-weight: bold;
   }
-  .sequence-sequence-list{
+
+  .sequence-sequence-list {
     border-left: 1px solid mat.get-theme-color($theme,outline);
     display: flex;
     flex-flow: column;
   }
-  .sequence-card-preview{
+
+  .sequence-card-preview {
     grid-column-start: 1;
     grid-column-end: 3;
     border-top: 2px solid mat.get-theme-color($theme,outline);
@@ -53,14 +55,14 @@
     flex-flow: column;
   }
 
-  .flashcard-sequence{
+  .flashcard-sequence {
     height:67%;
     aspect-ratio: 16 9;
     background-color: mat.get-theme-color($theme,primary-container);
     margin: auto;
   }
 
-  .sequence-tab-right{
+  .sequence-tab-right {
     grid-column-start: 2;
     grid-column-end: 3;
     border-top-right-radius: 12px;
@@ -70,11 +72,11 @@
     font:mat.get-theme-typography($theme, title-medium);
   }
 
-  .flashcard-container{
+  .flashcard-container {
     margin: auto;
   }
 
-  .remove-button{
+  .remove-button {
     background-color: mat.get-theme-color($theme, primary);
     color: mat.get-theme-color($theme, on-primary);
   }

--- a/src/app/sequence-editor/_sequence-editor-theme.scss
+++ b/src/app/sequence-editor/_sequence-editor-theme.scss
@@ -63,21 +63,20 @@
   .sequence-tab-right{
     grid-column-start: 2;
     grid-column-end: 3;
-    padding-left: 16px;
-    padding-right: 16px;
     border-top-right-radius: 12px;
     height: calc(100vh - 312px);
     border: 2px solid mat.get-theme-color($theme,outline);
     border-left: 1px solid mat.get-theme-color($theme,outline);
     font:mat.get-theme-typography($theme, title-medium);
-    display: grid;
-    grid-template-columns: 2% 46% 46% 2%;
-    grid-auto-rows: max-content;
-    grid-gap: 1%;
   }
 
   .flashcard-container{
     margin: auto;
+  }
+
+  .remove-button{
+    background-color: mat.get-theme-color($theme, primary);
+    color: mat.get-theme-color($theme, on-primary);
   }
 }
 @mixin editor-theme($theme) {

--- a/src/app/sequence-editor/sequence-editor.component.html
+++ b/src/app/sequence-editor/sequence-editor.component.html
@@ -17,7 +17,7 @@
         @for( item of _sequences; track _sequences){
           <li class="sequence-menu-item" [ngClass] = "{'selected-list-item': item == selectedSequence }" (click)="onPreviewSelectSeq(item)">
             <div class = "sequence-name-box">{{item.name}}</div>
-            <button class="trash-can" mat-icon-button (click)="removeSequence(this.selectedSequence)">
+            <button class="trash-can" mat-icon-button *ngIf="this.selectedSequence==item" (click)="removeSequence(this.selectedSequence, $event)">
               <mat-icon>delete_outline</mat-icon>
             </button>
           </li>
@@ -33,19 +33,24 @@
       <div class="flashcard-container">
         <app-flashcard [scaleFactor]="cardScaleFactor" [flashcard]="selectedFlashcard"></app-flashcard>
       </div>
-      <button mat-flat-button class="add-to-sequence-button" (click)="addToSequence($event)">Add to Sequence</button>
+      <button mat-flat-button class="add-to-sequence-button" (click)="addToSequence(selectedFlashcard)">Add to Sequence</button>
     </div>
   </div>
 
-  <div class="sequence-tab-right">
-    <h3 class="sequence-section-title title-right">Sequence name 1</h3>
-    1.
-    <mat-card class="flashcard-edit">
-      <mat-card-title class="flashcard-edit-title">Term</mat-card-title>
-    </mat-card>
-    <mat-card class="flashcard-edit">
-      <mat-card-title class="flashcard-edit-title">Definition</mat-card-title>
-    </mat-card>
-    <mat-icon class="move-icon">menu</mat-icon>
+  <div class="sequence-tab-right" cd>
+    <h3 class="sequence-section-title title-right">{{selectedSequence.name}}</h3>
+    <div cdkDropList class="prev-card-list" (cdkDropListDropped)="drop($event)" [cdkDropListAutoScrollStep]="10">
+      @for (flashcard of selectedSequence.cardList; track selectedSequence.cardList; let i = $index) {
+        <div class="list-item">
+          {{i + 1}}.
+          <div cdkDrag>
+            <ec-card-preview [flashcard]="flashcard"></ec-card-preview>
+            <button mat-icon-button class="remove-button" (click)="removeFromSequence(i)">
+              <mat-icon>remove</mat-icon>
+            </button>
+          </div>
+        </div>
+      }
+    </div>
   </div>
 </div>

--- a/src/app/sequence-editor/sequence-editor.component.html
+++ b/src/app/sequence-editor/sequence-editor.component.html
@@ -17,7 +17,7 @@
         @for( item of _sequences; track _sequences){
           <li class="sequence-menu-item" [ngClass] = "{'selected-list-item': item == selectedSequence }" (click)="onPreviewSelectSeq(item)">
             <div class = "sequence-name-box">{{item.name}}</div>
-            <button class="trash-can" mat-icon-button *ngIf="this.selectedSequence==item" (click)="removeSequence(this.selectedSequence, $event)">
+            <button class="trash-can" mat-icon-button *ngIf="this.selectedSequence==item" (click)="removeSequence(this.selectedSequence)">
               <mat-icon>delete_outline</mat-icon>
             </button>
           </li>
@@ -37,20 +37,27 @@
     </div>
   </div>
 
-  <div class="sequence-tab-right" cd>
-    <h3 class="sequence-section-title title-right">{{selectedSequence.name}}</h3>
-    <div cdkDropList class="prev-card-list" (cdkDropListDropped)="drop($event)" [cdkDropListAutoScrollStep]="10">
-      @for (flashcard of selectedSequence.cardList; track selectedSequence.cardList; let i = $index) {
-        <div class="list-item">
-          {{i + 1}}.
-          <div cdkDrag>
-            <ec-card-preview [flashcard]="flashcard"></ec-card-preview>
-            <button mat-icon-button class="remove-button" (click)="removeFromSequence(i)">
-              <mat-icon>remove</mat-icon>
-            </button>
+  <div class="sequence-tab-right">
+    <div *ngIf="this.selectedSequence!=undefined; else showEmpty">
+      <mat-form-field class="sequence-name-input">
+        <input matInput type="text" [(ngModel)]="selectedSequence.name">
+      </mat-form-field>
+      <div cdkDropList class="prev-card-list" (cdkDropListDropped)="drop($event)" [cdkDropListAutoScrollStep]="10">
+        @for (flashcard of selectedSequence.cardList; track selectedSequence.cardList; let i = $index) {
+          <div class="list-item">
+            {{i + 1}}.
+            <div cdkDrag>
+              <ec-card-preview [flashcard]="flashcard"></ec-card-preview>
+              <button mat-icon-button class="remove-button" (click)="removeFromSequence(i)">
+                <mat-icon>remove</mat-icon>
+              </button>
+            </div>
           </div>
-        </div>
-      }
+        }
+      </div>
     </div>
+    <ng-template #showEmpty>
+      <h3 class="sequence-section-title">No Sequence Selected</h3>
+    </ng-template>
   </div>
 </div>

--- a/src/app/sequence-editor/sequence-editor.component.html
+++ b/src/app/sequence-editor/sequence-editor.component.html
@@ -40,6 +40,7 @@
   <div class="sequence-tab-right">
     <div class="sequence-preview" *ngIf="this.selectedSequence!=undefined; else showEmpty">
       <mat-form-field class="sequence-name-input">
+        <mat-label>Sequence Name</mat-label>
         <input matInput type="text" [(ngModel)]="selectedSequence.name">
       </mat-form-field>
       <div cdkDropList class="prev-card-list" (cdkDropListDropped)="drop($event)" [cdkDropListAutoScrollStep]="10">

--- a/src/app/sequence-editor/sequence-editor.component.html
+++ b/src/app/sequence-editor/sequence-editor.component.html
@@ -38,7 +38,7 @@
   </div>
 
   <div class="sequence-tab-right">
-    <div *ngIf="this.selectedSequence!=undefined; else showEmpty">
+    <div class="sequence-preview" *ngIf="this.selectedSequence!=undefined; else showEmpty">
       <mat-form-field class="sequence-name-input">
         <input matInput type="text" [(ngModel)]="selectedSequence.name">
       </mat-form-field>

--- a/src/app/sequence-editor/sequence-editor.component.scss
+++ b/src/app/sequence-editor/sequence-editor.component.scss
@@ -1,15 +1,15 @@
-.tabs{
+.tabs {
   padding-left: 6%;
   padding-right: 6%;
 }
 
-.sequence-content{
+.sequence-content {
   display: grid;
   grid-template-columns: 50% 50%;
   height: calc(100vh - 312px);
 }
 
-.sequence-section-title{
+.sequence-section-title {
   line-height: 0em;
   text-align: center;
 }
@@ -21,7 +21,7 @@
   margin-top: 16px;
 }
 
-.card-list{
+.card-list {
   list-style-type: none;
   padding-left: 0px;
   margin:0;
@@ -29,13 +29,13 @@
   flex-grow:1;
 }
 
-.add-to-sequence-button{
+.add-to-sequence-button {
   margin-top: 8px;
   margin-bottom: 16px;
   align-self: center;
 }
 
-.title-right{
+.title-right {
   grid-column-start: 1;
   grid-column-end: 5;
 }
@@ -56,18 +56,18 @@
   transform: scale(0.75);
 }
 
-.sequence-menu-item{
+.sequence-menu-item {
   display: flex;
   height: 36px;
 }
 
-.sequence-name-box{
+.sequence-name-box {
   padding-left: 8px;
   flex-grow: 1;
   align-self: center;
 }
 
-.delete-button{
+.delete-button {
   align-self: flex-end;
 }
 

--- a/src/app/sequence-editor/sequence-editor.component.scss
+++ b/src/app/sequence-editor/sequence-editor.component.scss
@@ -14,6 +14,13 @@
   text-align: center;
 }
 
+.sequence-name-input {
+  width: calc(100% - 32px);
+  margin-left: 16px;
+  margin-right: 16px;
+  margin-top: 16px;
+}
+
 .card-list{
   list-style-type: none;
   padding-left: 0px;

--- a/src/app/sequence-editor/sequence-editor.component.scss
+++ b/src/app/sequence-editor/sequence-editor.component.scss
@@ -79,9 +79,8 @@
 }
 
 .prev-card-list {
-  padding-top: var(--padding-extra-small);
   overflow: auto;
-  height: calc(100% - 44px);
+  height: calc(100% - 92px);
 }
 
 .list-item {
@@ -93,4 +92,8 @@
   grid-template-columns: min-content auto;
   column-gap: 8px;
   position: relative;
+}
+
+.sequence-preview {
+  height: 100%;
 }

--- a/src/app/sequence-editor/sequence-editor.component.scss
+++ b/src/app/sequence-editor/sequence-editor.component.scss
@@ -39,12 +39,19 @@
   right: 16px;
 }
 
+.remove-button {
+  position: absolute;
+  transform: scale(0.75);
+  bottom: 4px;
+}
+
 .trash-can {
   transform: scale(0.75);
 }
 
 .sequence-menu-item{
   display: flex;
+  height: 36px;
 }
 
 .sequence-name-box{
@@ -62,4 +69,21 @@
   padding-left: 8px;
   align-items: center;
   height: 36px;
+}
+
+.prev-card-list {
+  padding-top: var(--padding-extra-small);
+  overflow: auto;
+  height: calc(100% - 44px);
+}
+
+.list-item {
+  padding-top: var(--padding-extra-small);
+  padding-bottom: var(--padding-extra-small);
+  padding-left: var(--padding-small);
+  padding-right: var(--padding-small);
+  display: grid;
+  grid-template-columns: min-content auto;
+  column-gap: 8px;
+  position: relative;
 }

--- a/src/app/sequence-editor/sequence-editor.component.ts
+++ b/src/app/sequence-editor/sequence-editor.component.ts
@@ -5,9 +5,14 @@ import { MatButtonToggleModule } from '@angular/material/button-toggle';
 import { MatCardModule } from '@angular/material/card';
 import { MatIconModule } from '@angular/material/icon';
 import { FlashcardComponent } from '../flashcard/flashcard.component';
-import { FlashcardEditorComponent } from '../flashcard-editor/flashcard-editor.component';
 import { SequenceData } from '../data-models/sequence-model';
 import { FlashcardData } from '../data-models/flashcard-model';
+import { EcCardPreviewComponent } from '../ec-card-preview/ec-card-preview.component';
+import {
+  CdkDragDrop,
+  DragDropModule,
+  moveItemInArray
+} from '@angular/cdk/drag-drop';
 
 @Component({
   selector: 'app-sequence-editor',
@@ -19,7 +24,8 @@ import { FlashcardData } from '../data-models/flashcard-model';
     MatCardModule,
     MatIconModule,
     FlashcardComponent,
-    FlashcardEditorComponent
+    EcCardPreviewComponent,
+    DragDropModule
   ],
   templateUrl: './sequence-editor.component.html',
   styleUrl: './sequence-editor.component.scss'
@@ -32,7 +38,8 @@ export class SequenceEditorComponent {
   /** Flashcard scale factor */
   cardScaleFactor: number = this.calculateScaleFactor();
   _sequences: SequenceData[] = [];
-  selectedSequence: SequenceData = new SequenceData("error");
+  private readonly emptySet: SequenceData = new SequenceData("No Selected Sequence");
+  selectedSequence: SequenceData = this.emptySet;
   _flashcards: FlashcardData[] = [];
   selectedFlashcard: FlashcardData = new FlashcardData();
 
@@ -62,17 +69,24 @@ export class SequenceEditorComponent {
     this.cardScaleFactor = this.calculateScaleFactor();
   }
 
-  addToSequence(e: Event) {
-    e.stopPropagation();
+  addToSequence(flashcard: FlashcardData) {
+    if(this.selectedSequence != this.emptySet) {
+      this.selectedSequence.addCard(flashcard);
+    }
   }
 
   addSequence(){
     this.addSequenceEvent.emit(true);
   }
 
-  removeSequence(seq: SequenceData) {
-    this.selectedSequence = seq;
+  removeSequence(seq: SequenceData, e: Event) {
+    e.stopPropagation();
+    this.selectedSequence = this.emptySet;
     this.removeSequenceEvent.emit(seq);
+  }
+
+  removeFromSequence(flashIndex: number) {
+    this.selectedSequence.removeCardAtIndex(flashIndex);
   }
 
   onPreviewSelectSeq(sequence: SequenceData) {
@@ -88,5 +102,9 @@ export class SequenceEditorComponent {
       window.innerWidth * this.widthSF,
       window.innerHeight * this.heightSF
     );
+  }
+
+  drop(event: CdkDragDrop<string[]>) {
+    moveItemInArray(this.selectedSequence.cardList, event.previousIndex, event.currentIndex);
   }
 }

--- a/src/app/sequence-editor/sequence-editor.component.ts
+++ b/src/app/sequence-editor/sequence-editor.component.ts
@@ -13,6 +13,9 @@ import {
   DragDropModule,
   moveItemInArray
 } from '@angular/cdk/drag-drop';
+import { MatInputModule } from '@angular/material/input';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { FormsModule } from '@angular/forms';
 
 @Component({
   selector: 'app-sequence-editor',
@@ -25,7 +28,10 @@ import {
     MatIconModule,
     FlashcardComponent,
     EcCardPreviewComponent,
-    DragDropModule
+    DragDropModule,
+    MatInputModule,
+    MatFormFieldModule,
+    FormsModule
   ],
   templateUrl: './sequence-editor.component.html',
   styleUrl: './sequence-editor.component.scss'
@@ -38,8 +44,7 @@ export class SequenceEditorComponent {
   /** Flashcard scale factor */
   cardScaleFactor: number = this.calculateScaleFactor();
   _sequences: SequenceData[] = [];
-  private readonly emptySet: SequenceData = new SequenceData("No Selected Sequence");
-  selectedSequence: SequenceData = this.emptySet;
+  selectedSequence: SequenceData | undefined = undefined;
   _flashcards: FlashcardData[] = [];
   selectedFlashcard: FlashcardData = new FlashcardData();
 
@@ -48,7 +53,9 @@ export class SequenceEditorComponent {
 
   @Input() set sequences(sequence:SequenceData[]) {
     this._sequences = sequence;
-    this.selectedSequence = this.sequences[0];
+    if(sequence.length != 0) {
+      this.selectedSequence = this.sequences[0];
+    }
   }
 
   get sequences() {
@@ -70,7 +77,7 @@ export class SequenceEditorComponent {
   }
 
   addToSequence(flashcard: FlashcardData) {
-    if(this.selectedSequence != this.emptySet) {
+    if(this.selectedSequence != undefined) {
       this.selectedSequence.addCard(flashcard);
     }
   }
@@ -79,14 +86,15 @@ export class SequenceEditorComponent {
     this.addSequenceEvent.emit(true);
   }
 
-  removeSequence(seq: SequenceData, e: Event) {
-    e.stopPropagation();
-    this.selectedSequence = this.emptySet;
+  removeSequence(seq: SequenceData) {
+    this.selectedSequence = undefined;
     this.removeSequenceEvent.emit(seq);
   }
 
   removeFromSequence(flashIndex: number) {
-    this.selectedSequence.removeCardAtIndex(flashIndex);
+    if(this.selectedSequence != undefined) {
+      this.selectedSequence.removeCardAtIndex(flashIndex);
+    }
   }
 
   onPreviewSelectSeq(sequence: SequenceData) {
@@ -105,6 +113,8 @@ export class SequenceEditorComponent {
   }
 
   drop(event: CdkDragDrop<string[]>) {
-    moveItemInArray(this.selectedSequence.cardList, event.previousIndex, event.currentIndex);
+    if(this.selectedSequence != undefined) {
+      moveItemInArray(this.selectedSequence.cardList, event.previousIndex, event.currentIndex);
+    }
   }
 }


### PR DESCRIPTION
fixes #32 #33 and #34

- Created a sequence preview and an empty sequence preview for when no sequence is selected
- Selected flashcards can be added to the sequence. Users can add multiple of the same sequence
- Flashcards can be removed from a selected sequence
  - A new method in the SequenceData was added to remove a flashcard by index, since removing a card by flashcard could remove the wrong instance of a flashcard.
- Users can rename a sequence from the sequence preview
- The flashcards in the sequence can be dragged
- I altered the select sequence so that the trash can only shows up when the sequence is selected
- The EC page tabs now include the number of flashcards/sequences in the set