### PR TITLE
116 update user sets

### DIFF
--- a/src/app/data-models/user-model.ts
+++ b/src/app/data-models/user-model.ts
@@ -94,7 +94,7 @@ export class UserData {
   }
 
   // Sets up JSON.stringify to properly stringify maps
-  toJSON(){
+  toJSON() {
     return {
         uid: this.uid,
         _recentSets: this.getRecentSets(),

--- a/src/app/edit-create-study-set/edit-create-study-set.component.ts
+++ b/src/app/edit-create-study-set/edit-create-study-set.component.ts
@@ -37,7 +37,7 @@ import { UserInfoService } from '../services/user-info.service';
   styleUrl: './edit-create-study-set.component.scss'
 })
 export class EditCreateStudySetComponent {
-  @Input() userId: string = sessionStorage.getItem("uid")!; // remove later
+  @Input() userId: string = sessionStorage.getItem("uid")!;
   studySet: StudySetData = new StudySetData(this.userId);
   isLoaded: boolean = false;
   constructor(

--- a/src/app/edit-create-study-set/edit-create-study-set.component.ts
+++ b/src/app/edit-create-study-set/edit-create-study-set.component.ts
@@ -16,6 +16,7 @@ import { FlashcardData } from '../data-models/flashcard-model';
 import { SequenceData } from '../data-models/sequence-model';
 import { getStudySetFromUrl } from '../utilities/route-helper';
 import { RouteParamNotFound } from '../errors/route-param-error';
+import { UserInfoService } from '../services/user-info.service';
 
 @Component({
   selector: 'app-edit-create-study-set',
@@ -43,7 +44,8 @@ export class EditCreateStudySetComponent {
     private studySetService: StudySetService,
     private router: Router,
     private route: ActivatedRoute,
-    private dialogRef: MatDialog
+    private dialogRef: MatDialog,
+    private userInfoService: UserInfoService,
   ) {
     // needed to reload the component if user goes from "edit" to "create"
     // we should implement our own strategy for router reuse in another task
@@ -84,6 +86,7 @@ export class EditCreateStudySetComponent {
       this.studySetService.saveStudySet(this.studySet).subscribe(newId => [
         this.router.navigate(["view-set"], { queryParams:{ sid: newId }})
       ]);
+      this.userInfoService.updateViewDate(this.studySet);
     } else {
       this.dialogRef.open(SavePopUpComponent);
     }

--- a/src/app/edit-create-study-set/edit-create-study-set.component.ts
+++ b/src/app/edit-create-study-set/edit-create-study-set.component.ts
@@ -37,7 +37,7 @@ import { UserInfoService } from '../services/user-info.service';
   styleUrl: './edit-create-study-set.component.scss'
 })
 export class EditCreateStudySetComponent {
-  @Input() userId: string = "no Id passed"; // remove later
+  @Input() userId: string = sessionStorage.getItem("uid")!; // remove later
   studySet: StudySetData = new StudySetData(this.userId);
   isLoaded: boolean = false;
   constructor(
@@ -86,7 +86,7 @@ export class EditCreateStudySetComponent {
       this.studySetService.saveStudySet(this.studySet).subscribe(newId => [
         this.router.navigate(["view-set"], { queryParams:{ sid: newId }})
       ]);
-      this.userInfoService.updateViewDate(this.studySet);
+
     } else {
       this.dialogRef.open(SavePopUpComponent);
     }

--- a/src/app/homepage/homepage.component.ts
+++ b/src/app/homepage/homepage.component.ts
@@ -26,9 +26,6 @@ import { SlickCarouselModule, SlickCarouselComponent } from 'ngx-slick-carousel'
   styleUrl: './homepage.component.scss',
 })
 export class HomepageComponent {
-  // @Input() userData!:UserData;
-  // @Input() userId: string = "there wasn't a userId passed to this"; // remove later
-
   userInfo: UserData = new UserData;
   recentSetList: AccessData[] = this.userInfo.getRecentSets();
   userSetList: AccessData[] = this.userInfo.getOwnedSets();

--- a/src/app/services/study-set-dev.service.ts
+++ b/src/app/services/study-set-dev.service.ts
@@ -39,19 +39,13 @@ export class StudySetDevService extends StudySetService {
 
   override saveStudySet(studySet: StudySetModel): Observable<string> {
     if(!studySet.id) {
-      let setIdVar: string;
-      let setObservable = this.http.post(`${this.baseUrl}${this.studySetEndpoint}`, {
+      return this.http.post(`${this.baseUrl}${this.studySetEndpoint}`, {
           owner: studySet.owner,
           title: studySet.title,
           description: studySet.description,
           flashcards: studySet.flashcards,
           sequences: studySet.sequences,
         }).pipe(map((studySet) => StudySetData.copyStudySet(studySet as StudySetModel).id as string));
-        setObservable.pipe(take(1)).subscribe(setId => {
-          setIdVar = setId;
-          sessionStorage.setItem(setIdVar,JSON.stringify(studySet));
-        });
-      return setObservable;
     } else {
       sessionStorage.setItem(studySet.id,JSON.stringify(studySet));
       return this.http.put(`${this.baseUrl}${this.studySetEndpoint}/${studySet.id}`, {

--- a/src/app/services/study-set-firebase.service.ts
+++ b/src/app/services/study-set-firebase.service.ts
@@ -56,8 +56,9 @@ export class StudySetFirebaseService extends StudySetService {
       sequences: sequences
     }) as Promise<void> ))
       .pipe(map(() => studySet.id = docRef.id));
-    sessionStorage.removeItem(docRef.id);
-    this.getStudySet(docRef.id);
+    setId.pipe(take(1)).subscribe(x => {
+      sessionStorage.setItem(x,JSON.stringify(studySet))
+    } )
     return setId;
   }
 }

--- a/src/app/services/study-set-firebase.service.ts
+++ b/src/app/services/study-set-firebase.service.ts
@@ -55,10 +55,11 @@ export class StudySetFirebaseService extends StudySetService {
       flashcards: studySet.flashcards.map(obj => Object.assign({}, obj)),
       sequences: sequences
     }) as Promise<void> ))
-      .pipe(map(() => studySet.id = docRef.id));
-    setId.pipe(take(1)).subscribe(x => {
-      sessionStorage.setItem(x,JSON.stringify(studySet))
-    } )
+      .pipe(map(() => {
+        studySet.id = docRef.id
+        sessionStorage.setItem(docRef.id,JSON.stringify(studySet));
+        return studySet.id;
+      }));
     return setId;
   }
 }

--- a/src/app/services/study-set-firebase.service.ts
+++ b/src/app/services/study-set-firebase.service.ts
@@ -56,6 +56,7 @@ export class StudySetFirebaseService extends StudySetService {
       sequences: sequences
     }) as Promise<void> ))
       .pipe(map(() => studySet.id = docRef.id));
+    sessionStorage.removeItem(docRef.id);
     this.getStudySet(docRef.id);
     return setId;
   }

--- a/src/app/services/study-set-firebase.service.ts
+++ b/src/app/services/study-set-firebase.service.ts
@@ -41,14 +41,13 @@ export class StudySetFirebaseService extends StudySetService {
   override saveStudySet(studySet: StudySetModel): Observable<string> {
     const docRef = studySet.id ?
       doc(this.firestore, 'study-sets', studySet.id) : doc(collection(this.firestore, 'study-sets'));
-    sessionStorage.setItem(docRef.id,JSON.stringify(studySet));;
     // firebase does not accept custom objects, so must turn into array of structs
     const sequences = studySet.sequences.map((seq) => ({
       id: seq.id,
       name: seq.name,
       cardList: seq.cardList.map(card => Object.assign({}, card))
     }))
-    return defer(() => from(setDoc(docRef, {
+    let setId =  defer(() => from(setDoc(docRef, {
       id: docRef.id,
       owner: studySet.owner,
       title: studySet.title,
@@ -57,5 +56,7 @@ export class StudySetFirebaseService extends StudySetService {
       sequences: sequences
     }) as Promise<void> ))
       .pipe(map(() => studySet.id = docRef.id));
+    this.getStudySet(docRef.id);
+    return setId;
   }
 }

--- a/src/app/services/user-info-fake.service.ts
+++ b/src/app/services/user-info-fake.service.ts
@@ -80,8 +80,10 @@ export class UserInfoFakeService extends UserInfoService {
     this.loadUser(sessionStorage.getItem("uid")!)
     .pipe(take(1)).subscribe(user =>{
       user.updateRecentSets({setId: studySet.id! , viewed: new Date()});
-      if (studySet.owner === sessionStorage.getItem("uid")){
-        user.updateOwned({setId: studySet.id! , viewed: new Date()});
+      if (studySet.owner){
+          if (studySet.owner === sessionStorage.getItem("uid")){
+          user.updateOwned({setId: studySet.id! , viewed: new Date()});
+        }
       }
       this.saveUser(user);
     })

--- a/src/app/services/user-info-fake.service.ts
+++ b/src/app/services/user-info-fake.service.ts
@@ -2,6 +2,9 @@ import { Injectable } from '@angular/core';
 import { AccessStorageData, UserData } from '../data-models/user-model';
 import { of, Observable } from 'rxjs';
 import { UserInfoService } from './user-info.service';
+import { StudySetData } from '../data-models/studyset-model';
+import { take } from 'rxjs';
+
 
 @Injectable({
   providedIn: 'root'
@@ -71,5 +74,16 @@ export class UserInfoFakeService extends UserInfoService {
     // so I needed placeholder things
     sessionStorage.setItem(user.uid,JSON.stringify(user));
     return of("");
+  }
+
+  override updateViewDate(studySet: StudySetData){
+    this.loadUser(sessionStorage.getItem("uid")!)
+    .pipe(take(1)).subscribe(user =>{
+      user.updateRecentSets({setId: studySet.id! , viewed: new Date()});
+      if (studySet.owner === sessionStorage.getItem("uid")){
+        user.updateOwned({setId: studySet.id! , viewed: new Date()});
+      }
+      this.saveUser(user);
+    })
   }
 }

--- a/src/app/services/user-info-fake.service.ts
+++ b/src/app/services/user-info-fake.service.ts
@@ -76,12 +76,12 @@ export class UserInfoFakeService extends UserInfoService {
     return of("");
   }
 
-  override updateViewDate(studySet: StudySetData){
+  override updateViewDate(studySet: StudySetData) {
     this.loadUser(sessionStorage.getItem("uid")!)
-    .pipe(take(1)).subscribe(user =>{
+    .pipe(take(1)).subscribe(user => {
       user.updateRecentSets({setId: studySet.id! , viewed: new Date()});
-      if (studySet.owner){
-          if (studySet.owner === sessionStorage.getItem("uid")){
+      if (studySet.owner) {
+          if (studySet.owner === sessionStorage.getItem("uid")) {
           user.updateOwned({setId: studySet.id! , viewed: new Date()});
         }
       }

--- a/src/app/services/user-info-fake.service.ts
+++ b/src/app/services/user-info-fake.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { AccessStorageData, AccessData, UserData } from '../data-models/user-model';
+import { AccessStorageData, UserData } from '../data-models/user-model';
 import { of, Observable } from 'rxjs';
 import { UserInfoService } from './user-info.service';
 
@@ -60,7 +60,7 @@ export class UserInfoFakeService extends UserInfoService {
         }
       ];
 
-      const user = new UserData(id, setList, setList);;
+      const user = new UserData(id, setList, setList);
       sessionStorage.setItem(id,JSON.stringify(user));
       return of(user);
     }

--- a/src/app/services/user-info-firebase.service.ts
+++ b/src/app/services/user-info-firebase.service.ts
@@ -48,8 +48,12 @@ export class UserInfoFirebaseService extends UserInfoService {
       recentSets: user.getRecentSetsToStore()
     }) as Promise<void> ))
       .pipe(map((ret => user.uid as string)));
-      console.log(user.getOwnedSetsToStore())
-      return x
+
+      //Save user doesn't save to firebase unless this is here, it's 6:00am
+      x.subscribe(a =>{
+        console.log("Save User")
+      })
+    return x
   }
 
   override updateViewDate(studySet: StudySetData){

--- a/src/app/services/user-info-firebase.service.ts
+++ b/src/app/services/user-info-firebase.service.ts
@@ -42,7 +42,7 @@ export class UserInfoFirebaseService extends UserInfoService {
 
   override saveUser(user: UserData): Observable<string> {
     sessionStorage.setItem(user.uid,JSON.stringify(user));
-    let x = defer(() => from(setDoc(doc(collection(this.firestore, 'users'), user.uid), {
+    let userid = defer(() => from(setDoc(doc(collection(this.firestore, 'users'), user.uid), {
       uid: user.uid,
       ownedSets: user.getOwnedSetsToStore(),
       recentSets: user.getRecentSetsToStore()
@@ -50,10 +50,10 @@ export class UserInfoFirebaseService extends UserInfoService {
       .pipe(map((ret => user.uid as string)));
 
       //Save user doesn't save to firebase unless this is here, it's 6:00am
-      x.subscribe(a =>{
+      userid.subscribe(a =>{
         console.log("Save User")
       })
-    return x
+    return userid
   }
 
   override updateViewDate(studySet: StudySetData){

--- a/src/app/services/user-info-firebase.service.ts
+++ b/src/app/services/user-info-firebase.service.ts
@@ -48,24 +48,19 @@ export class UserInfoFirebaseService extends UserInfoService {
       recentSets: user.getRecentSetsToStore()
     }) as Promise<void> ))
       .pipe(map((ret => user.uid as string)));
-
-      //Save user doesn't save to firebase unless this is here, it's 6:00am
-      userid.subscribe(a =>{
-        console.log("Save User")
-      })
     return userid
   }
 
-  override updateViewDate(studySet: StudySetData){
+  override updateViewDate(studySet: StudySetData) {
     this.loadUser(sessionStorage.getItem("uid")!)
-    .pipe(take(1)).subscribe(user =>{
+    .pipe(take(1)).subscribe(user => {
       user.updateRecentSets({setId: studySet.id! , viewed: new Date()});
-      if(studySet.owner){
-        if (studySet.owner === sessionStorage.getItem("uid")){
+      if (studySet.owner) {
+        if (studySet.owner === sessionStorage.getItem("uid")) {
         user.updateOwned({setId: studySet.id! , viewed: new Date()});
         }
       }
-      this.saveUser(user);
+      this.saveUser(user).subscribe();
     })
   }
 }

--- a/src/app/services/user-info-firebase.service.ts
+++ b/src/app/services/user-info-firebase.service.ts
@@ -6,6 +6,7 @@ import {
   DocumentSnapshot } from '@angular/fire/firestore';
 import { Observable, defer, from, map, switchMap, of, take } from 'rxjs';
 import { UserData, UserModel } from '../data-models/user-model';
+import { StudySetData } from '../data-models/studyset-model';
 
 @Injectable({
   providedIn: 'root'
@@ -48,5 +49,16 @@ export class UserInfoFirebaseService extends UserInfoService {
       recentSets: user.getRecentSetsToStore()
     }) as Promise<void> ))
       .pipe(map((ret => user.uid as string)));
+  }
+
+  override updateViewDate(studySet: StudySetData){
+    this.loadUser(sessionStorage.getItem("uid")!)
+    .pipe(take(1)).subscribe(user =>{
+      user.updateRecentSets({setId: studySet.id! , viewed: new Date()});
+      if (studySet.owner === sessionStorage.getItem("uid")){
+        user.updateOwned({setId: studySet.id! , viewed: new Date()});
+      }
+      this.saveUser(user);
+    })
   }
 }

--- a/src/app/services/user-info.service.ts
+++ b/src/app/services/user-info.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { UserData } from '../data-models/user-model';
+import { StudySetData } from '../data-models/studyset-model';
 
 @Injectable({
   providedIn: 'root'
@@ -9,4 +10,6 @@ export abstract class UserInfoService {
   abstract loadUser(id: string): Observable<UserData>;
 
   abstract saveUser(user: UserData): Observable<string>;
+
+  abstract updateViewDate(studySet: StudySetData): void;
 }

--- a/src/app/set-preview-card/set-preview-card.component.html
+++ b/src/app/set-preview-card/set-preview-card.component.html
@@ -4,7 +4,7 @@
     <div class="study-set-badge">
       {{studySet.flashcards.length}} Terms
     </div>
-    <div class="study-set-badge">
+    <div class="study-set-badge" [ngClass]="{'hidden-badge':!sequenceLength}">
       {{studySet.sequences.length}} Sequences
     </div>
   </div>

--- a/src/app/set-preview-card/set-preview-card.component.scss
+++ b/src/app/set-preview-card/set-preview-card.component.scss
@@ -36,6 +36,9 @@
   padding-right: 8px;
   box-shadow: 0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.24);
 }
+.hidden-badge{
+  visibility: hidden;
+}
 
 .study-set-description{
   display: -webkit-box;

--- a/src/app/set-preview-card/set-preview-card.component.ts
+++ b/src/app/set-preview-card/set-preview-card.component.ts
@@ -21,6 +21,7 @@ export class SetPreviewCardComponent {
   setId: string | undefined;
   userId: string = "no uid";
   studySet: StudySetData = new StudySetData(this.userId);
+  sequenceLength: Number = 0;
 
   @Input() AccessDataIn!: AccessData;
 
@@ -35,6 +36,7 @@ export class SetPreviewCardComponent {
     this.studySetService.getStudySet(setId)
       .subscribe(sSet => [
         this.studySet = sSet,
+        this.sequenceLength = sSet.sequences.length
       ]);
   }
 

--- a/src/app/study-flashcard/study-flashcard.component.ts
+++ b/src/app/study-flashcard/study-flashcard.component.ts
@@ -7,6 +7,8 @@ import { CommonModule } from '@angular/common';
 import { MatIcon } from '@angular/material/icon';
 import { getStudySetFromUrl } from '../utilities/route-helper';
 import { ActivatedRoute } from '@angular/router';
+import { UserInfoService } from '../services/user-info.service';
+import { StudySetData } from '../data-models/studyset-model';
 
 @Component({
   selector: 'app-study-flashcard',
@@ -29,14 +31,17 @@ export class StudyFlashcardComponent {
   currentFlashcard: FlashcardData = new FlashcardData();
   currentCardIndex: number = 0;
   setId?: string;
+  studySet!: StudySetData;
 
   constructor(
     private studySetService: StudySetService,
-    private route: ActivatedRoute
+    private route: ActivatedRoute,
+    private userInfoService: UserInfoService,
   ) { }
 
   ngOnInit() {
     this.loadFlashcards();
+    this.userInfoService.updateViewDate(this.studySet)
   }
 
   loadFlashcards() {
@@ -44,7 +49,8 @@ export class StudyFlashcardComponent {
       .subscribe(sSet => [
         this.flashcards = sSet.flashcards,
         this.setId = sSet.id,
-        this.currentFlashcard = this.flashcards[this.currentCardIndex]
+        this.currentFlashcard = this.flashcards[this.currentCardIndex],
+        this.studySet = sSet
       ]);
   }
 

--- a/src/app/study-flashcard/study-flashcard.component.ts
+++ b/src/app/study-flashcard/study-flashcard.component.ts
@@ -89,7 +89,7 @@ export class StudyFlashcardComponent {
     this.cardScaleFactor = this.calculateScaleFactor();
   }
 
-  calculateScaleFactor(){
+  calculateScaleFactor() {
     return Math.min(
       window.innerWidth * this.widthSF,
       window.innerHeight * this.heightSF

--- a/src/app/study-sequence/study-sequence.component.ts
+++ b/src/app/study-sequence/study-sequence.component.ts
@@ -18,6 +18,7 @@ import { getStudySetFromUrl } from '../utilities/route-helper';
 import { ActivatedRoute } from '@angular/router';
 import { MatDialog} from '@angular/material/dialog';
 import { CheckPopUpComponent } from '../check-pop-up/check-pop-up.component';
+import { UserInfoService } from '../services/user-info.service';
 
 export interface CardMap {
   key: number,
@@ -54,11 +55,13 @@ export class StudySequenceComponent {
   constructor(
     private studySetService: StudySetService,
     private route: ActivatedRoute,
-    private dialogRef: MatDialog
+    private dialogRef: MatDialog,
+    private userInfoService: UserInfoService,
   ) {}
 
   ngOnInit() {
     this.loadStudySet();
+    this.userInfoService.updateViewDate(this.studySet!);
   }
 
   loadStudySet() {

--- a/src/app/study-sequence/study-sequence.component.ts
+++ b/src/app/study-sequence/study-sequence.component.ts
@@ -116,13 +116,13 @@ export class StudySequenceComponent {
     }
   }
 
-  changeSelectedSequence(sequence: SequenceData){
+  changeSelectedSequence(sequence: SequenceData) {
     this.selectedSeq = sequence;
     this.clearSequence();
     this.generateCardPool();
   }
 
-  showAnswer(){
+  showAnswer() {
     this.clearSequence();
     setTimeout(() => {
       this.selectedSeq.cardList.forEach((flashcard) => {
@@ -133,20 +133,20 @@ export class StudySequenceComponent {
     });
   }
 
-  clearSequence(){
+  clearSequence() {
     this.userSeq = [];
     this.cardPool = this.basePool.map(x => Object.assign({}, x));
   }
 
-  checkAnswer(){
-    if (this.userSeq.length != this.selectedSeq.cardList.length){
+  checkAnswer() {
+    if (this.userSeq.length != this.selectedSeq.cardList.length) {
       this.dialogRef.open(CheckPopUpComponent, {
         data: {answer: 'Incorrect!'}
       });
       return;
     }
-    for(let i = 0; i < this.userSeq.length; i++){
-      if (this.userSeq[i].card != this.selectedSeq.cardList[i]){
+    for(let i = 0; i < this.userSeq.length; i++) {
+      if (this.userSeq[i].card != this.selectedSeq.cardList[i]) {
         this.dialogRef.open(CheckPopUpComponent, {
           data: {answer: 'Incorrect!'}
         });

--- a/src/app/user-set-card/user-set-card.component.html
+++ b/src/app/user-set-card/user-set-card.component.html
@@ -1,7 +1,7 @@
 <mat-card class = user-sets-card [routerLink]="['/view-set']" [queryParams]="{sid: setId}">
   <mat-card-title>{{studySet.title}}</mat-card-title>
   <div class="study-set-badge">{{studySet.flashcards.length}} Terms</div>
-  <div class="study-set-badge">{{studySet.sequences.length}} Sequences</div>
+  <div class="study-set-badge" [ngClass]="{'hidden-badge' : !sequenceLength}">{{studySet.sequences.length}} Sequences</div>
   <mat-card-title class="viewed-date-label">Last viewed:</mat-card-title>
   <mat-card-title class="viewed-date">{{viewDate}}</mat-card-title>
 </mat-card>

--- a/src/app/user-set-card/user-set-card.component.scss
+++ b/src/app/user-set-card/user-set-card.component.scss
@@ -29,6 +29,9 @@
   box-shadow: 0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.24);
   text-wrap: nowrap;
 }
+.hidden-badge{
+  visibility: hidden;
+}
 
 .viewed-date-label{
   justify-self: right;

--- a/src/app/user-set-card/user-set-card.component.ts
+++ b/src/app/user-set-card/user-set-card.component.ts
@@ -21,6 +21,7 @@ export class UserSetCardComponent {
   @Input() setId: string | undefined;
   @Input() userId: string = "there wasn't a userId passed to this"; // remove later
   studySet: StudySetData = new StudySetData(this.userId);
+  sequenceLength: Number = 0;
 
   @Input() AccessDataIn!: AccessData;
   viewDate: string = "no date";
@@ -41,6 +42,7 @@ export class UserSetCardComponent {
     this.studySetService.getStudySet(setId)
       .subscribe(sSet => [
         this.studySet = sSet,
+        this.sequenceLength = sSet.sequences.length
       ]);
   }
 }

--- a/src/app/view-study-set/view-study-set.component.ts
+++ b/src/app/view-study-set/view-study-set.component.ts
@@ -17,7 +17,7 @@ import { SequenceData } from '../data-models/sequence-model';
 import { CommonModule } from '@angular/common';
 import { UserInfoService } from '../services/user-info.service';
 import { take } from 'rxjs';
-import { AccessData } from '../data-models/user-model';
+
 
 @Component({
   selector: 'app-view-study-set',
@@ -48,7 +48,7 @@ export class ViewStudySetComponent {
 
   ngOnInit() {
     this.loadStudySet();
-    this.updateViewDate()
+    this.userInfoService.updateViewDate(this.studySet)
   }
 
   @HostListener('window:resize', ['$event'])
@@ -63,17 +63,6 @@ export class ViewStudySetComponent {
         this.studySet = sSet,
         this.activeSequence = this.studySet.sequences[0],
       ]);
-  }
-
-  updateViewDate(){
-    this.userInfoService.loadUser(sessionStorage.getItem("uid")!)
-    .pipe(take(1)).subscribe(user =>{
-      user.updateRecentSets({setId: this.studySet.id! , viewed: new Date()});
-      if (this.studySet.owner === sessionStorage.getItem("uid")){
-        user.updateOwned({setId: this.studySet.id! , viewed: new Date()});
-      }
-      this.userInfoService.saveUser(user);
-    })
   }
 
   ngAfterViewChecked() {

--- a/src/app/view-study-set/view-study-set.component.ts
+++ b/src/app/view-study-set/view-study-set.component.ts
@@ -16,7 +16,6 @@ import { getStudySetFromUrl } from '../utilities/route-helper';
 import { SequenceData } from '../data-models/sequence-model';
 import { CommonModule } from '@angular/common';
 import { UserInfoService } from '../services/user-info.service';
-import { take } from 'rxjs';
 
 
 @Component({

--- a/src/app/view-study-set/view-study-set.component.ts
+++ b/src/app/view-study-set/view-study-set.component.ts
@@ -47,7 +47,6 @@ export class ViewStudySetComponent {
 
   ngOnInit() {
     this.loadStudySet();
-    this.userInfoService.updateViewDate(this.studySet)
   }
 
   @HostListener('window:resize', ['$event'])
@@ -61,6 +60,7 @@ export class ViewStudySetComponent {
       .subscribe(sSet => [
         this.studySet = sSet,
         this.activeSequence = this.studySet.sequences[0],
+        this.userInfoService.updateViewDate(this.studySet)
       ]);
   }
 

--- a/src/app/view-study-set/view-study-set.component.ts
+++ b/src/app/view-study-set/view-study-set.component.ts
@@ -15,6 +15,9 @@ import { FlashcardData } from '../data-models/flashcard-model';
 import { getStudySetFromUrl } from '../utilities/route-helper';
 import { SequenceData } from '../data-models/sequence-model';
 import { CommonModule } from '@angular/common';
+import { UserInfoService } from '../services/user-info.service';
+import { take } from 'rxjs';
+import { AccessData } from '../data-models/user-model';
 
 @Component({
   selector: 'app-view-study-set',
@@ -40,10 +43,12 @@ export class ViewStudySetComponent {
     private studySetService: StudySetService,
     private route: ActivatedRoute,
     private dialogRef: MatDialog,
+    private userInfoService: UserInfoService,
   ) {}
 
   ngOnInit() {
     this.loadStudySet();
+    this.updateViewDate()
   }
 
   @HostListener('window:resize', ['$event'])
@@ -56,8 +61,19 @@ export class ViewStudySetComponent {
     getStudySetFromUrl(this.route, this.studySetService)
       .subscribe(sSet => [
         this.studySet = sSet,
-        this.activeSequence = this.studySet.sequences[0]
+        this.activeSequence = this.studySet.sequences[0],
       ]);
+  }
+
+  updateViewDate(){
+    this.userInfoService.loadUser(sessionStorage.getItem("uid")!)
+    .pipe(take(1)).subscribe(user =>{
+      user.updateRecentSets({setId: this.studySet.id! , viewed: new Date()});
+      if (this.studySet.owner === sessionStorage.getItem("uid")){
+        user.updateOwned({setId: this.studySet.id! , viewed: new Date()});
+      }
+      this.userInfoService.saveUser(user);
+    })
   }
 
   ngAfterViewChecked() {

--- a/src/environments/environment.development.ts
+++ b/src/environments/environment.development.ts
@@ -1,6 +1,6 @@
 export const environment = {
   production: false,
-  useFirebase: true,  // change to switch between json server or firebase
+  useFirebase: false,  // change to switch between json server or firebase
   firebaseConfig: {
     apiKey: "AIzaSyAe-LRL9nl_QioUv8HnPjF-gr7X-ccurcY",
     authDomain: "ponder-hosting.firebaseapp.com",

--- a/src/environments/environment.development.ts
+++ b/src/environments/environment.development.ts
@@ -1,6 +1,6 @@
 export const environment = {
   production: false,
-  useFirebase: false,  // change to switch between json server or firebase
+  useFirebase: true,  // change to switch between json server or firebase
   firebaseConfig: {
     apiKey: "AIzaSyAe-LRL9nl_QioUv8HnPjF-gr7X-ccurcY",
     authDomain: "ponder-hosting.firebaseapp.com",


### PR DESCRIPTION
fixes #116 

Theoretically this should update user's recent and owned lists when viewing a set.
After editing a set, the user is sent back to view page, so it'll update there.

json server: all sets belong to "user1" so owned sets will not update without tweaks (edit json, session storage, etc)

firebase save user doesn't work without the subscribe statement, I can look into it in the future.

