### PR TITLE
43 reorder sequence in side bar

### DIFF
--- a/src/app/sequence-sidebar/sequence-sidebar.component.html
+++ b/src/app/sequence-sidebar/sequence-sidebar.component.html
@@ -1,8 +1,10 @@
-@for (item of userSequence; track userSequence; let i = $index) {
-  <div class="sequence-entry">
-    <h1>{{i + 1}}.</h1>
-    <app-sequence-card [flashcard]="item.card" (removeFromSeqEvent)="removeFromSeq(item)" [inSequence]="true"></app-sequence-card>
-    <mat-icon aria-hidden="false" aria-label="Menu">menu</mat-icon>
-  </div>
-}
-<div class="empty-square"></div>
+<div cdkDropList class="sequence-items" (cdkDropListDropped)="drop($event)">
+  @for (item of userSequence; track userSequence; let i = $index) {
+    <div class="sequence-entry" cdkDrag>
+      <h1>{{i + 1}}.</h1>
+      <app-sequence-card [flashcard]="item.card" (removeFromSeqEvent)="removeFromSeq(item)" [inSequence]="true"></app-sequence-card>
+      <mat-icon aria-hidden="false" aria-label="Menu">menu</mat-icon>
+    </div>
+  }
+  <div class="empty-square"></div>
+</div>

--- a/src/app/sequence-sidebar/sequence-sidebar.component.html
+++ b/src/app/sequence-sidebar/sequence-sidebar.component.html
@@ -1,9 +1,11 @@
 <div cdkDropList class="sequence-items" (cdkDropListDropped)="drop($event)" [cdkDropListAutoScrollStep]="10">
   @for (item of userSequence; track userSequence; let i = $index) {
-    <div class="sequence-entry" cdkDrag>
+    <div class="sequence-entry">
       <h1>{{i + 1}}.</h1>
-      <app-sequence-card [flashcard]="item.card" (removeFromSeqEvent)="removeFromSeq(item)" [inSequence]="true"></app-sequence-card>
-      <mat-icon aria-hidden="false" aria-label="Menu">menu</mat-icon>
+      <div class="drag-area" cdkDrag>
+        <app-sequence-card [flashcard]="item.card" (removeFromSeqEvent)="removeFromSeq(item)" [inSequence]="true"></app-sequence-card>
+        <mat-icon aria-hidden="false" aria-label="Menu">menu</mat-icon>
+      </div>
     </div>
   }
   <div class="empty-square"></div>

--- a/src/app/sequence-sidebar/sequence-sidebar.component.html
+++ b/src/app/sequence-sidebar/sequence-sidebar.component.html
@@ -3,7 +3,10 @@
     <div class="sequence-entry">
       <h1>{{i + 1}}.</h1>
       <div class="drag-area" cdkDrag>
-        <app-sequence-card [flashcard]="item.card" (removeFromSeqEvent)="removeFromSeq(item)" [inSequence]="true"></app-sequence-card>
+        <app-sequence-card [flashcard]="item.card" 
+          (removeFromSeqEvent)="removeFromSeq(item)" 
+          [inSequence]="true">
+        </app-sequence-card>
         <mat-icon aria-hidden="false" aria-label="Menu">menu</mat-icon>
       </div>
     </div>

--- a/src/app/sequence-sidebar/sequence-sidebar.component.html
+++ b/src/app/sequence-sidebar/sequence-sidebar.component.html
@@ -1,4 +1,4 @@
-<div cdkDropList class="sequence-items" (cdkDropListDropped)="drop($event)">
+<div cdkDropList class="sequence-items" (cdkDropListDropped)="drop($event)" [cdkDropListAutoScrollStep]="10">
   @for (item of userSequence; track userSequence; let i = $index) {
     <div class="sequence-entry" cdkDrag>
       <h1>{{i + 1}}.</h1>

--- a/src/app/sequence-sidebar/sequence-sidebar.component.scss
+++ b/src/app/sequence-sidebar/sequence-sidebar.component.scss
@@ -5,6 +5,11 @@
   align-items: center;
 }
 
+.drag-area{
+  display: flex;
+  align-items: center;
+}
+
 h1{
   padding-right: 16px;
 }

--- a/src/app/sequence-sidebar/sequence-sidebar.component.ts
+++ b/src/app/sequence-sidebar/sequence-sidebar.component.ts
@@ -2,11 +2,12 @@ import { Component, Input, Output, EventEmitter } from '@angular/core';
 import { SequenceCardComponent } from '../sequence-card/sequence-card.component';
 import { CardMap } from '../study-sequence/study-sequence.component';
 import {MatIconModule } from '@angular/material/icon';
+import { CdkDragDrop, DragDropModule, moveItemInArray } from '@angular/cdk/drag-drop';
 
 @Component({
   selector: 'app-sequence-sidebar',
   standalone: true,
-  imports: [SequenceCardComponent, MatIconModule],
+  imports: [SequenceCardComponent, MatIconModule, DragDropModule],
   templateUrl: './sequence-sidebar.component.html',
   styleUrl: './sequence-sidebar.component.scss'
 })
@@ -16,5 +17,9 @@ export class SequenceSidebarComponent {
 
   removeFromSeq(item: CardMap) {
     this.removeFromSeqEvent.emit(item);
+  }
+
+  drop(event: CdkDragDrop<string[]>){
+    moveItemInArray(this.userSequence, event.previousIndex, event.currentIndex)
   }
 }

--- a/src/app/sequence-sidebar/sequence-sidebar.component.ts
+++ b/src/app/sequence-sidebar/sequence-sidebar.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input, Output, EventEmitter } from '@angular/core';
 import { SequenceCardComponent } from '../sequence-card/sequence-card.component';
 import { CardMap } from '../study-sequence/study-sequence.component';
-import {MatIconModule } from '@angular/material/icon';
+import { MatIconModule } from '@angular/material/icon';
 import { CdkDragDrop, DragDropModule, moveItemInArray } from '@angular/cdk/drag-drop';
 
 @Component({
@@ -19,7 +19,7 @@ export class SequenceSidebarComponent {
     this.removeFromSeqEvent.emit(item);
   }
 
-  drop(event: CdkDragDrop<string[]>){
-    moveItemInArray(this.userSequence, event.previousIndex, event.currentIndex)
+  drop(event: CdkDragDrop<string[]>) {
+    moveItemInArray(this.userSequence, event.previousIndex, event.currentIndex);
   }
 }

--- a/src/app/study-sequence/study-sequence.component.html
+++ b/src/app/study-sequence/study-sequence.component.html
@@ -19,7 +19,7 @@
     </mat-menu>
   </div>
   <div class="sequence-builder">
-    <div class="cards-in-sequence">
+    <div class="cards-in-sequence" cdkScrollable>
       <app-sequence-sidebar [userSequence]="userSeq"
         (removeFromSeqEvent)="removeFromSequence($event)">
       </app-sequence-sidebar>


### PR DESCRIPTION
Fixes #43 

# Reorder sequence sidebar by dragging
- Made items in sequence sidebar draggable.
- Sidebar will scroll when dragged to the top or bottom.
- Dragging updates the sequence, checking answer should correspond with the new sequence.