### PR TITLE
125 empty set default homepage

### DIFF
--- a/src/app/homepage/_homepage-theme.scss
+++ b/src/app/homepage/_homepage-theme.scss
@@ -5,12 +5,12 @@
   .section-title{
     font: mat.get-theme-typography($theme, headline-medium);
   }
-  .carousel-buttons{
+  .carousel-buttons, .create-set-button {
     background-color: mat.get-theme-color($theme, primary);
     color: mat.get-theme-color($theme, on-primary);
   }
 
-  .slick-slide{
+  .slick-slide {
     padding: 4px;
     padding-top: 2px;
     padding-bottom: 9px;
@@ -34,5 +34,9 @@
     li.slick-active button:before {
       background-color: mat.get-theme-color($theme,primary);
     }
+  }
+
+  .empty-message {
+    font: mat.get-theme-typography($theme, headline-medium);
   }
 }

--- a/src/app/homepage/_homepage-theme.scss
+++ b/src/app/homepage/_homepage-theme.scss
@@ -2,7 +2,7 @@
 @use '@angular/material-experimental' as matx;
 
 @mixin homepage-theme($theme) {
-  .section-title{
+  .section-title {
     font: mat.get-theme-typography($theme, headline-medium);
   }
   .carousel-buttons, .create-set-button {

--- a/src/app/homepage/homepage.component.html
+++ b/src/app/homepage/homepage.component.html
@@ -3,9 +3,9 @@
 </head>
 
 <body>
-  <div class = "recent-container">
-    <h1 class = "section-title">Recent</h1>
-    <div class="recent-carousel">
+  <div class="recent-container">
+    <h1 class="section-title">Recent</h1>
+    <div class="recent-carousel" *ngIf="recentLength">
       <ngx-slick-carousel #slickModal="slick-carousel" [config]="slideConfig">
         <app-set-preview-card ngxSlickItem *ngFor="let recentSet of recentSetList"
         [AccessDataIn]="recentSet"></app-set-preview-card>
@@ -19,13 +19,27 @@
         <mat-icon>arrow_forward</mat-icon>
       </button>
     </div>
+    <div class="recent-set-empty" *ngIf="!recentLength">
+      <div class="empty-message">You have not accessed any sets recently</div>
+      <button mat-flat-button class="create-set-button" [routerLink]="['/edit-set']">
+        Create Study Set
+        <mat-icon>add</mat-icon>
+      </button>
+    </div>
   </div>
 
-  <div class = "user-sets-container">
-    <h1 class = "section-title">Your Sets</h1>
-    <div class = "user-sets-list">
+  <div class="user-sets-container">
+    <h1 class="section-title">Your Sets</h1>
+    <div class="user-sets-list" *ngIf="ownedLength">
       <app-user-set-card *ngFor="let userSet of userSetList"
       [AccessDataIn]="userSet"></app-user-set-card>
+    </div>
+    <div class="user-set-empty" *ngIf="!ownedLength">
+      <div class="empty-message">You have no study sets saved</div>
+      <button mat-flat-button class="create-set-button" [routerLink]="['/edit-set']">
+        Create Study Set
+        <mat-icon>add</mat-icon>
+      </button>
     </div>
   </div>
 </body>

--- a/src/app/homepage/homepage.component.scss
+++ b/src/app/homepage/homepage.component.scss
@@ -34,6 +34,7 @@
   flex-direction: column;
   height: 270px;
   flex-basis: 100%;
+  text-align: center;
   align-items: center;
   justify-content: center;
 }
@@ -54,6 +55,7 @@
   flex-direction: column;
   height: 80%;
   flex-basis: 100%;
+  text-align: center;
   align-items: center;
   justify-content: center;
 }

--- a/src/app/homepage/homepage.component.scss
+++ b/src/app/homepage/homepage.component.scss
@@ -1,20 +1,20 @@
-.recent-container{
+.recent-container {
   padding-left: 32px;
   padding-right: 32px;
   position: relative;
 }
 
-.section-title{
+.section-title {
   font-weight: bold;
 }
 
-.recent-carousel{
+.recent-carousel {
   margin-top: 4px;
   padding-left: 5px;
   height: 270px;
   width: 100%;
 }
-.carousel-buttons{
+.carousel-buttons {
   position: absolute;
   top: calc(50% - 18px);
   transform: translateY(-50%);
@@ -22,20 +22,41 @@
   height: 36px;
   box-shadow: 0 3px 6px rgba(0,0,0,0.16), 0 3px 6px rgba(0,0,0,0.23);
 }
-.carousel-buttons:first-child{
+.carousel-buttons:first-child {
   left:0px;
 }
-.carousel-buttons:last-child{
+.carousel-buttons:last-child {
   right:0px;
 }
 
-.user-sets-container{
+.recent-set-empty {
+  display: flex;
+  flex-direction: column;
+  height: 270px;
+  flex-basis: 100%;
+  align-items: center;
+  justify-content: center;
+}
+
+.user-sets-container {
   height: calc(100vh - 395px);
   padding-left: 32px;
   padding-right: 32px;
 }
-.user-sets-list{
+.user-sets-list {
   height: 92%;
   overflow-y: scroll;
   padding-top: 4px;
+}
+
+.user-set-empty {
+  display: flex;
+  flex-direction: column;
+  height: 80%;
+  flex-basis: 100%;
+  align-items: center;
+  justify-content: center;
+}
+.empty-message {
+  padding-bottom: 12px;
 }

--- a/src/app/homepage/homepage.component.ts
+++ b/src/app/homepage/homepage.component.ts
@@ -5,7 +5,6 @@ import { AccessData, UserData } from '../data-models/user-model';
 import { UserInfoService } from '../services/user-info.service';
 import { SetPreviewCardComponent } from '../set-preview-card/set-preview-card.component';
 import { UserSetCardComponent } from '../user-set-card/user-set-card.component';
-
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { SlickCarouselModule, SlickCarouselComponent } from 'ngx-slick-carousel';

--- a/src/app/homepage/homepage.component.ts
+++ b/src/app/homepage/homepage.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, ViewChild } from '@angular/core';
+import { Component, ViewChild } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
 import { AccessData, UserData } from '../data-models/user-model';
@@ -26,12 +26,11 @@ import { SlickCarouselModule, SlickCarouselComponent } from 'ngx-slick-carousel'
   styleUrl: './homepage.component.scss',
 })
 export class HomepageComponent {
-  // @Input() userData!:UserData;
-  // @Input() userId: string = "there wasn't a userId passed to this"; // remove later
-
   userInfo: UserData = new UserData;
   recentSetList: AccessData[] = this.userInfo.getRecentSets();
   userSetList: AccessData[] = this.userInfo.getOwnedSets();
+  ownedLength: Number = 0;
+  recentLength: Number = 0;
 
   constructor(private userInfoService: UserInfoService) {};
 
@@ -44,7 +43,9 @@ export class HomepageComponent {
       .subscribe(user => [
         this.userInfo = user,
         this.recentSetList = this.userInfo.getRecentSets(),
-        this.userSetList = this.userInfo.getOwnedSets()
+        this.userSetList = this.userInfo.getOwnedSets(),
+        this.ownedLength = this.userSetList?.length,
+        this.recentLength = this.recentSetList?.length,
       ]);
   }
 

--- a/src/app/set-preview-card/_set-preview-card-theme.scss
+++ b/src/app/set-preview-card/_set-preview-card-theme.scss
@@ -2,29 +2,29 @@
 @use '@angular/material-experimental' as matx;
 
 @mixin set-preview-card-theme($theme) {
-  .study-set-card{
+  .study-set-card {
     background-color: mat.get-theme-color($theme, surface-container-lowest);
   }
 
-  .study-set-title{
+  .study-set-title {
     font: mat.get-theme-typography($theme, title-medium);
   }
 
-  .study-set-badge{
+  .study-set-badge {
     font: mat.get-theme-typography($theme, label-medium);
     background-color: mat.get-theme-color($theme, secondary-container);
   }
 
-  .study-set-description{
+  .study-set-description {
     font: mat.get-theme-typography($theme, body-medium);
   }
 
-  .preview-grid mat-card{
+  .preview-grid mat-card {
     background-color: mat.get-theme-color($theme, primary-container);
     font: mat.get-theme-typography($theme, body-medium);
   }
 
-  .preview-grid mat-card-title{
+  .preview-grid mat-card-title {
     font: mat.get-theme-typography($theme, body-large);
   }
 

--- a/src/app/set-preview-card/set-preview-card.component.scss
+++ b/src/app/set-preview-card/set-preview-card.component.scss
@@ -12,7 +12,7 @@
   grid-gap:4px;
   box-shadow: 0 3px 6px rgba(0,0,0,0.16), 0 3px 6px rgba(0,0,0,0.23);
 }
-.study-set-title{
+.study-set-title {
   text-overflow: ellipsis;
   white-space: nowrap;
   overflow: clip;
@@ -22,11 +22,11 @@
   font-weight: bold;
 }
 
-.study-set-badge-row{
+.study-set-badge-row {
   width:100%;
   height: 100%;
 }
-.study-set-badge{
+.study-set-badge {
   width:fit-content;
   float: left;
   margin-left:8px;
@@ -37,7 +37,7 @@
   box-shadow: 0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.24);
 }
 
-.study-set-description{
+.study-set-description {
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
@@ -50,7 +50,7 @@
   padding-left: 4px;
 }
 
-.preview-grid{
+.preview-grid {
   width:100%;
   display: grid;
   grid-template-columns: 50% 50%;
@@ -58,12 +58,12 @@
   align-items: center;
   justify-items: center;
 }
-.preview-grid mat-card{
+.preview-grid mat-card {
   width: calc(100% - 4px);
   height: calc(100% - 4px);
   text-align: center;
 }
-.preview-grid mat-card-title{
+.preview-grid mat-card-title {
   display:-webkit-box;
   line-height: 1.2em;
   padding: 4px;

--- a/src/app/user-set-card/_user-set-card-theme.scss
+++ b/src/app/user-set-card/_user-set-card-theme.scss
@@ -2,15 +2,15 @@
 @use '@angular/material-experimental' as matx;
 
 @mixin user-set-theme($theme) {
-  .user-sets-card{
+  .user-sets-card {
     background-color: mat.get-theme-color($theme, surface-container-lowest);
   }
 
-  .user-sets-card mat-card-title{
+  .user-sets-card mat-card-title {
     font: mat.get-theme-typography($theme, headline-small);
   }
 
-  .study-set-badge{
+  .study-set-badge {
     font: mat.get-theme-typography($theme, label-medium);
     background-color: mat.get-theme-color($theme, secondary-container);
   }

--- a/src/app/user-set-card/user-set-card.component.scss
+++ b/src/app/user-set-card/user-set-card.component.scss
@@ -1,4 +1,4 @@
-.user-sets-card{
+.user-sets-card {
   display: grid;
   grid-template-columns: min-content min-content min-content auto min-content;
   width:99.5%;
@@ -12,12 +12,12 @@
   margin-left: 4px;
 }
 
-.user-sets-card mat-card-title{
+.user-sets-card mat-card-title {
   line-height: 1em;
   text-wrap:nowrap;
 }
 
-.study-set-badge{
+.study-set-badge {
   width:fit-content;
   float: left;
   margin-left:12px;
@@ -30,12 +30,12 @@
   text-wrap: nowrap;
 }
 
-.viewed-date-label{
+.viewed-date-label {
   justify-self: right;
   text-align: right;
   padding-right: 12px;
 }
-.viewed-date{
+.viewed-date {
   width: 4em;
 }
 


### PR DESCRIPTION
fixes #125 
When the user's recent list or owned list are empty, the page will correspondingly display the "empty set" message

If you have any preferences for what the message should say, feel free to change it to whatever you desire.

![image](https://github.com/PonderTeam/ponder-app/assets/80878588/09638e97-95b6-42b6-9cdb-29453b187097)
![image](https://github.com/PonderTeam/ponder-app/assets/80878588/c4fdba9e-655d-4897-945e-80b1e6a7a768)
![image](https://github.com/PonderTeam/ponder-app/assets/80878588/0bb3c88d-fcbb-4324-88bc-dff99a118248)

