### PR TITLE
27 upload image dev

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -29,6 +29,9 @@ import {
   QuerySuggestionFakeService,
   QuerySuggestionService,
   QuerySuggestionTypesenseService } from './services/query-suggestions/query-suggestion-module';
+import {
+  ImageService,
+  ImageDevService } from './services/image/image-service-module';
 
 export const appConfig: ApplicationConfig = {
   providers: [
@@ -74,6 +77,10 @@ export const appConfig: ApplicationConfig = {
     {
       provide: QuerySuggestionService,
       useClass: environment.useTypesense ? QuerySuggestionTypesenseService : QuerySuggestionFakeService
+    },
+    {
+      provide: ImageService,
+      useClass: environment.useFirebase ? ImageDevService : ImageDevService
     },
     { provide: MATERIAL_SANITY_CHECKS, useValue: false },
   ]

--- a/src/app/ec-card-preview/ec-card-preview.component.ts
+++ b/src/app/ec-card-preview/ec-card-preview.component.ts
@@ -4,6 +4,7 @@ import { MatIconModule } from '@angular/material/icon';
 import { CommonModule } from '@angular/common';
 import { FlashcardComponent } from '../flashcard/flashcard.component';
 import { calculateScaleFactor } from '../utilities/calculate-scaler';
+import { ecPreviewWidthSF, ecPreviewShift } from '../utilities/constants';
 
 @Component({
   selector: 'ec-card-preview',
@@ -14,11 +15,10 @@ import { calculateScaleFactor } from '../utilities/calculate-scaler';
 })
 export class EcCardPreviewComponent {
   @Input() flashcard: FlashcardModel = new FlashcardData("term", "definition (placeholder)");
-  private readonly widthSF: number = 0.22;
-  cardScaleFactor: number = calculateScaleFactor(this.widthSF,1, -46);
+  cardScaleFactor: number = calculateScaleFactor(ecPreviewWidthSF, 1, ecPreviewShift);
 
   @HostListener('window:resize', ['$event'])
   onResize(event: Event) {
-    this.cardScaleFactor = calculateScaleFactor(this.widthSF, 1, -46);
+    this.cardScaleFactor = calculateScaleFactor(ecPreviewWidthSF, 1, ecPreviewShift);
   }
 }

--- a/src/app/edit-create-study-set/edit-create-study-set.component.html
+++ b/src/app/edit-create-study-set/edit-create-study-set.component.html
@@ -35,7 +35,7 @@
           <app-tab-body>
             <app-flashcard-editor
               [flashcards]="studySet.flashcards"
-              [images]="images"
+              [cardsToUpdate]="cardsToUpdate"
               (addCardEvent)="addCard()"
               (removeCardEvent)="removeCard($event)">
             </app-flashcard-editor>

--- a/src/app/edit-create-study-set/edit-create-study-set.component.html
+++ b/src/app/edit-create-study-set/edit-create-study-set.component.html
@@ -35,6 +35,7 @@
           <app-tab-body>
             <app-flashcard-editor
               [flashcards]="studySet.flashcards"
+              [images]="images"
               (addCardEvent)="addCard()"
               (removeCardEvent)="removeCard($event)">
             </app-flashcard-editor>

--- a/src/app/edit-create-study-set/edit-create-study-set.component.html
+++ b/src/app/edit-create-study-set/edit-create-study-set.component.html
@@ -30,7 +30,6 @@
         <app-tab-body>
           <app-flashcard-editor
             [flashcards]="studySet.flashcards"
-            [cardsToUpdate]="cardsToUpdate"
             (addCardEvent)="addCard()"
             (removeCardEvent)="removeCard($event)">
           </app-flashcard-editor>

--- a/src/app/edit-create-study-set/edit-create-study-set.component.ts
+++ b/src/app/edit-create-study-set/edit-create-study-set.component.ts
@@ -40,6 +40,7 @@ export class EditCreateStudySetComponent {
   @Input() userId: string = sessionStorage.getItem("uid")!;
   studySet: StudySetData = new StudySetData(this.userId);
   isLoaded: boolean = false;
+  images: Map<string, string> = new Map<string, string>;
   constructor(
     private studySetService: StudySetService,
     private router: Router,

--- a/src/app/edit-create-study-set/edit-create-study-set.component.ts
+++ b/src/app/edit-create-study-set/edit-create-study-set.component.ts
@@ -40,7 +40,6 @@ export class EditCreateStudySetComponent {
   @Input() userId: string = sessionStorage.getItem("uid")!;
   studySet: StudySetData = new StudySetData(this.userId);
   isLoaded: boolean = false;
-  cardsToUpdate: Set<number> = new Set<number>;
   constructor(
     private studySetService: StudySetService,
     private router: Router,
@@ -90,7 +89,6 @@ export class EditCreateStudySetComponent {
 
   saveSet() {
     if (this.studySet.isValid()) {
-      this.uploadImages();
       this.studySetService.saveStudySet(this.studySet).subscribe(newId => [
         this.router.navigate(["view-set"], { queryParams:{ sid: newId }})
       ]);
@@ -114,14 +112,5 @@ export class EditCreateStudySetComponent {
 
   removeSequence(seq: SequenceData) {
     this.studySet.deleteSequence(seq);
-  }
-
-  uploadImages() {
-    for(let fid of this.cardsToUpdate) {
-      let cardToUpdate = this.studySet.flashcards.find((flashcard) => flashcard.id == fid)!;
-      this.imageService.uploadImage(cardToUpdate.image).subscribe(path => {
-        cardToUpdate.image = path;
-      });
-    }
   }
 }

--- a/src/app/edit-create-study-set/edit-create-study-set.component.ts
+++ b/src/app/edit-create-study-set/edit-create-study-set.component.ts
@@ -60,7 +60,6 @@ export class EditCreateStudySetComponent {
         window.scrollTo(0, 0);
       }
       if (evt instanceof NavigationStart) {
-        console.log(this.images);
         for(let image of this.images) {
           sessionStorage.removeItem(image[1])
         }
@@ -117,12 +116,12 @@ export class EditCreateStudySetComponent {
   }
 
   uploadImages() {
-    for(let image of this.images) {
-      this.imageService.uploadImage(<string>sessionStorage.getItem(image[1])).subscribe(path => {
-        let cardToUpdate = this.studySet.flashcards.find((flashcard) => flashcard.id == image[0])!;
+    for(let [fid, img] of this.images) {
+      this.imageService.uploadImage(<string>sessionStorage.getItem(img)).subscribe(path => {
+        let cardToUpdate = this.studySet.flashcards.find((flashcard) => flashcard.id == fid)!;
         cardToUpdate.image = path;
-        sessionStorage.removeItem(image[1]);
-        this.images.delete(image[0]);
+        sessionStorage.removeItem(img);
+        this.images.delete(fid);
       });
     }
   }

--- a/src/app/edit-create-study-set/edit-create-study-set.component.ts
+++ b/src/app/edit-create-study-set/edit-create-study-set.component.ts
@@ -4,7 +4,7 @@ import { MatButtonModule } from '@angular/material/button';
 import { FormsModule } from '@angular/forms';
 import { MatInputModule } from '@angular/material/input';
 import { MatFormFieldModule } from '@angular/material/form-field';
-import { RouterLink, Router, ActivatedRoute, NavigationEnd, NavigationStart } from '@angular/router';
+import { RouterLink, Router, ActivatedRoute, NavigationEnd } from '@angular/router';
 import { CustomTabsModule } from '../custom-tabs/custom-tabs.module';
 import { FlashcardEditorComponent } from '../flashcard-editor/flashcard-editor.component';
 import { SequenceEditorComponent } from '../sequence-editor/sequence-editor.component';
@@ -39,7 +39,6 @@ export class EditCreateStudySetComponent {
   @Input() userId: string = sessionStorage.getItem("uid")!;
   studySet: StudySetData = new StudySetData(this.userId);
   isLoaded: boolean = false;
-  cardsToUpdate: Map<number, string> = new Map<number, string>;
   constructor(
     private studySetService: StudySetService,
     private router: Router,

--- a/src/app/edit-create-study-set/edit-create-study-set.component.ts
+++ b/src/app/edit-create-study-set/edit-create-study-set.component.ts
@@ -40,7 +40,7 @@ export class EditCreateStudySetComponent {
   @Input() userId: string = sessionStorage.getItem("uid")!;
   studySet: StudySetData = new StudySetData(this.userId);
   isLoaded: boolean = false;
-  images: Map<number, string> = new Map<number, string>;
+  cardsToUpdate: Set<number> = new Set<number>;
   constructor(
     private studySetService: StudySetService,
     private router: Router,
@@ -58,11 +58,6 @@ export class EditCreateStudySetComponent {
       if (evt instanceof NavigationEnd) {
         this.router.navigated = false;
         window.scrollTo(0, 0);
-      }
-      if (evt instanceof NavigationStart) {
-        for(let image of this.images) {
-          sessionStorage.removeItem(image[1])
-        }
       }
     });
   };
@@ -116,12 +111,10 @@ export class EditCreateStudySetComponent {
   }
 
   uploadImages() {
-    for(let [fid, img] of this.images) {
-      this.imageService.uploadImage(<string>sessionStorage.getItem(img)).subscribe(path => {
-        let cardToUpdate = this.studySet.flashcards.find((flashcard) => flashcard.id == fid)!;
+    for(let fid of this.cardsToUpdate) {
+      let cardToUpdate = this.studySet.flashcards.find((flashcard) => flashcard.id == fid)!;
+      this.imageService.uploadImage(cardToUpdate.image).subscribe(path => {
         cardToUpdate.image = path;
-        sessionStorage.removeItem(img);
-        this.images.delete(fid);
       });
     }
   }

--- a/src/app/edit-create-study-set/edit-create-study-set.component.ts
+++ b/src/app/edit-create-study-set/edit-create-study-set.component.ts
@@ -16,7 +16,6 @@ import { FlashcardData } from '../data-models/flashcard-model';
 import { SequenceData } from '../data-models/sequence-model';
 import { getStudySetFromUrl } from '../utilities/route-helper';
 import { RouteParamNotFound } from '../errors/route-param-error';
-import { ImageService } from '../services/image/image.service';
 
 @Component({
   selector: 'app-edit-create-study-set',
@@ -40,12 +39,12 @@ export class EditCreateStudySetComponent {
   @Input() userId: string = sessionStorage.getItem("uid")!;
   studySet: StudySetData = new StudySetData(this.userId);
   isLoaded: boolean = false;
+  cardsToUpdate: Map<number, string> = new Map<number, string>;
   constructor(
     private studySetService: StudySetService,
     private router: Router,
     private route: ActivatedRoute,
     private dialogRef: MatDialog,
-    private imageService: ImageService,
   ) {
     // needed to reload the component if user goes from "edit" to "create"
     // we should implement our own strategy for router reuse in another task
@@ -92,7 +91,6 @@ export class EditCreateStudySetComponent {
       this.studySetService.saveStudySet(this.studySet).subscribe(newId => [
         this.router.navigate(["view-set"], { queryParams:{ sid: newId }})
       ]);
-
     } else {
       this.dialogRef.open(SavePopUpComponent);
     }

--- a/src/app/enlarged-flashcard/enlarged-flashcard.component.ts
+++ b/src/app/enlarged-flashcard/enlarged-flashcard.component.ts
@@ -11,6 +11,7 @@ import {
 import { SequenceCardComponent } from '../sequence-card/sequence-card.component';
 import {MatButtonModule} from '@angular/material/button';
 import { calculateScaleFactor } from '../utilities/calculate-scaler';
+import { studyFlashcardHeightSF, studyFlashcardWidthSF } from '../utilities/constants';
 
 @Component({
   selector: 'app-enlarged-flashcard',
@@ -25,9 +26,7 @@ import { calculateScaleFactor } from '../utilities/calculate-scaler';
   styleUrl: './enlarged-flashcard.component.scss'
 })
 export class EnlargedFlashcardComponent {
-  private readonly widthSF = (880 / 1280);
-  private readonly heightSF = (496 / 720);
-  scaleFactor: number = calculateScaleFactor(this.widthSF, this.heightSF);
+  scaleFactor: number = calculateScaleFactor(studyFlashcardWidthSF, studyFlashcardHeightSF);
 
   constructor(
     public dialogRef: MatDialogRef<SequenceCardComponent>,
@@ -40,6 +39,6 @@ export class EnlargedFlashcardComponent {
 
   @HostListener('window:resize', ['$event'])
   onResize(event: Event) {
-    this.scaleFactor = calculateScaleFactor(this.widthSF, this.heightSF);
+    this.scaleFactor = calculateScaleFactor(studyFlashcardWidthSF, studyFlashcardHeightSF);
   }
 }

--- a/src/app/flashcard-editor/_flashcard-editor-theme.scss
+++ b/src/app/flashcard-editor/_flashcard-editor-theme.scss
@@ -50,6 +50,10 @@
     display: flex;
     flex-flow: column;
   }
+
+  #delete-image {
+    color: mat.get-theme-color($theme, error);
+  }
 }
 
 @mixin editor-theme($theme) {

--- a/src/app/flashcard-editor/_flashcard-editor-theme.scss
+++ b/src/app/flashcard-editor/_flashcard-editor-theme.scss
@@ -5,7 +5,7 @@
   .flashcards-content {
     display: grid;
     grid-template-columns: 50% 50%;
-    height: calc(100vh - 312px);
+    height: calc(100vh - 316px);
   }
 
   .flashcard-tab-left {

--- a/src/app/flashcard-editor/flashcard-editor.component.html
+++ b/src/app/flashcard-editor/flashcard-editor.component.html
@@ -52,7 +52,7 @@
         <button mat-icon-button id="delete-image" *ngIf="hoverImage" (click)="removeImage()">
           <mat-icon>delete-outline</mat-icon>
         </button>
-        <img id="image-preview"  src={{selectedCard.image}}>
+        <img id="image-preview"  src={{imageService.loadImage(selectedCard.image)}}>
       </div>
     </div>
     <div id="card-count">{{selectedIndex + 1}} of {{flashcards.length}}</div>

--- a/src/app/flashcard-editor/flashcard-editor.component.html
+++ b/src/app/flashcard-editor/flashcard-editor.component.html
@@ -33,20 +33,28 @@
         [maxlength]="28">
     </mat-form-field>
     Definition:
-    <mat-form-field id="definition-textbox">
-      <textarea matInput
-        cdkTextareaAutosize
-        cdkAutosizeMinRows="1"
-        cdkAutosizeMaxRows="15"
-        type="text"
-        placeholder="Definition"
-        [(ngModel)]="selectedCard.definition"
-        [maxlength]="selectedCard.hasImage()? 72 : 144">
-      </textarea>
-      <mat-hint align="start">
-        {{selectedCard.definition.length}} / {{selectedCard.hasImage()? 72 : 144}}
-      </mat-hint>
-    </mat-form-field>
+    <div id="def-space">
+      <mat-form-field id="definition-textbox" [style.width]="selectedCard.hasImage()? '49%' : '100%'">
+        <textarea matInput
+          cdkTextareaAutosize
+          cdkAutosizeMinRows="1"
+          cdkAutosizeMaxRows="15"
+          type="text"
+          placeholder="Definition"
+          [(ngModel)]="selectedCard.definition"
+          [maxlength]="selectedCard.hasImage()? 72 : 144">
+        </textarea>
+        <mat-hint align="start">
+          {{selectedCard.definition.length}} / {{selectedCard.hasImage()? 72 : 144}}
+        </mat-hint>
+      </mat-form-field>
+      <div id="image-area" *ngIf="selectedCard.hasImage()" (mouseenter)="hoverImage=true" (mouseleave)="hoverImage=false">
+        <button mat-icon-button id="delete-image" *ngIf="hoverImage" (click)="removeImage()">
+          <mat-icon>delete-outline</mat-icon>
+        </button>
+        <img id="image-preview"  src={{selectedCard.image}}>
+      </div>
+    </div>
     <div id="card-count">{{selectedIndex + 1}} of {{flashcards.length}}</div>
     <button mat-fab extended id="delete-button" class="button" (click)="removeCard(this.selectedCard)">
       <mat-icon>remove</mat-icon>

--- a/src/app/flashcard-editor/flashcard-editor.component.html
+++ b/src/app/flashcard-editor/flashcard-editor.component.html
@@ -42,10 +42,10 @@
           type="text"
           placeholder="Definition"
           [(ngModel)]="selectedCard.definition"
-          [maxlength]="selectedCard.hasImage()? 72 : 144">
+          [maxlength]="selectedCard.hasImage()? maxTextImage : maxText">
         </textarea>
         <mat-hint align="start">
-          {{selectedCard.definition.length}} / {{selectedCard.hasImage()? 72 : 144}}
+          {{selectedCard.definition.length}} / {{selectedCard.hasImage()? maxTextImage : maxText}}
         </mat-hint>
       </mat-form-field>
       <div id="image-area" *ngIf="selectedCard.hasImage()" (mouseenter)="hoverImage=true" (mouseleave)="hoverImage=false">

--- a/src/app/flashcard-editor/flashcard-editor.component.html
+++ b/src/app/flashcard-editor/flashcard-editor.component.html
@@ -20,6 +20,9 @@
       <mat-icon>format_bold</mat-icon>
       <mat-icon>format_italic</mat-icon>
       <mat-icon>format_underline</mat-icon>
+      <button class="picture-button" *ngIf="!selectedCard.hasImage()" mat-icon-button (click)="uploadImage()">
+        <mat-icon>add_photo_alternate</mat-icon>
+      </button>
     </div>
     Term:
     <mat-form-field id="term-textbox">

--- a/src/app/flashcard-editor/flashcard-editor.component.scss
+++ b/src/app/flashcard-editor/flashcard-editor.component.scss
@@ -55,9 +55,7 @@
 
 #image-preview {
   width: 100%;
-  //height: 100%;
   object-fit: contain;
-  //float: right;
 }
 
 #image-area {
@@ -68,7 +66,7 @@
 
 #delete-image {
   position: absolute;
-  bottom: 16px;
+  top: 16px;
   right: 8px;
   scale: 1.5;
 }

--- a/src/app/flashcard-editor/flashcard-editor.component.scss
+++ b/src/app/flashcard-editor/flashcard-editor.component.scss
@@ -18,9 +18,12 @@
   align-self: center;
 }
 
-#definition-textbox {
-  width: 100%;
+#def-space {
   flex-grow: 1;
+}
+
+#definition-textbox {
+  height: 100%;
 }
 
 #term-textbox {
@@ -48,4 +51,24 @@
   mat-icon {
     margin-right: 0;
   }
+}
+
+#image-preview {
+  width: 100%;
+  //height: 100%;
+  object-fit: contain;
+  //float: right;
+}
+
+#image-area {
+  position: relative;
+  float: right;
+  width: 50%;
+}
+
+#delete-image {
+  position: absolute;
+  bottom: 16px;
+  right: 8px;
+  scale: 1.5;
 }

--- a/src/app/flashcard-editor/flashcard-editor.component.ts
+++ b/src/app/flashcard-editor/flashcard-editor.component.ts
@@ -43,9 +43,10 @@ export class FlashcardEditorComponent {
   selectedIndex: number = 0;
   highlight: boolean = true;
   hoverImage: boolean = false;
+
   @Output() addCardEvent = new EventEmitter<void>;
   @Output() removeCardEvent = new EventEmitter<FlashcardData>;
-
+  @Input() images: Map<string, string> = new Map<string, string>();
   @Input() set flashcards(card: FlashcardData[]) {
     this._flashcards = card;
     this.selectedCard = this.flashcards[0];
@@ -106,13 +107,20 @@ export class FlashcardEditorComponent {
   }
 
   uploadImage() {
-    this.dialogRef.open(
+    let dialog = this.dialogRef.open(
       UploadPopupComponent,
-      {width: "50vw", data: this.selectedCard}
+      {width: "50vw", data: this.selectedCard, disableClose: true}
     )
+    dialog.afterClosed().subscribe(res => {
+      if(res.data.path != "") {
+        this.images.set(res.data.path, res.data.data);
+        this.selectedCard.image = res.data.path;
+      }
+    })
   }
 
   removeImage() {
+    this.images.delete(this.selectedCard.image)
     this.selectedCard.image = "";
   }
 }

--- a/src/app/flashcard-editor/flashcard-editor.component.ts
+++ b/src/app/flashcard-editor/flashcard-editor.component.ts
@@ -45,7 +45,7 @@ export class FlashcardEditorComponent {
   selectedIndex: number = 0;
   highlight: boolean = true;
   hoverImage: boolean = false;
-  maxText: number = maxText
+  maxText: number = maxText;
   maxTextImage: number = maxTextImage;
 
   @Output() addCardEvent = new EventEmitter<void>;
@@ -114,7 +114,7 @@ export class FlashcardEditorComponent {
   uploadImage() {
     let dialog = this.dialogRef.open(
       UploadPopupComponent,
-      { data: this.selectedCard, disableClose: true}
+      { maxWidth: '100vh', data: this.selectedCard, disableClose: true}
     );
 
     dialog.afterClosed().subscribe(res => {

--- a/src/app/flashcard-editor/flashcard-editor.component.ts
+++ b/src/app/flashcard-editor/flashcard-editor.component.ts
@@ -15,6 +15,8 @@ import {
   moveItemInArray
 } from '@angular/cdk/drag-drop';
 import $ from "jquery";
+import { MatDialog, MatDialogModule } from '@angular/material/dialog';
+import { UploadPopupComponent } from '../upload-popup/upload-popup.component';
 
 @Component({
   selector: 'app-flashcard-editor',
@@ -29,7 +31,8 @@ import $ from "jquery";
     MatCardModule,
     MatIconModule,
     EcCardPreviewComponent,
-    DragDropModule
+    DragDropModule,
+    MatDialogModule
   ],
   templateUrl: './flashcard-editor.component.html',
   styleUrl: './flashcard-editor.component.scss'
@@ -49,6 +52,10 @@ export class FlashcardEditorComponent {
   get flashcards() {
     return this._flashcards;
   }
+
+  constructor(
+    private dialogRef: MatDialog
+  ) {}
 
   ngAfterViewChecked() {
     this.placeDeleteButton();
@@ -95,5 +102,12 @@ export class FlashcardEditorComponent {
     $('#delete-button').css({
         'left': (window.innerWidth*.5) + rightWidth! - buttonWidth! - 16
     });
+  }
+
+  uploadImage() {
+    this.dialogRef.open(
+      UploadPopupComponent,
+      {width: "50vw", data: this.selectedCard}
+    )
   }
 }

--- a/src/app/flashcard-editor/flashcard-editor.component.ts
+++ b/src/app/flashcard-editor/flashcard-editor.component.ts
@@ -42,6 +42,7 @@ export class FlashcardEditorComponent {
   selectedCard: FlashcardData = new FlashcardData("error", "error");
   selectedIndex: number = 0;
   highlight: boolean = true;
+  hoverImage: boolean = false;
   @Output() addCardEvent = new EventEmitter<void>;
   @Output() removeCardEvent = new EventEmitter<FlashcardData>;
 
@@ -109,5 +110,9 @@ export class FlashcardEditorComponent {
       UploadPopupComponent,
       {width: "50vw", data: this.selectedCard}
     )
+  }
+
+  removeImage() {
+    this.selectedCard.image = "";
   }
 }

--- a/src/app/flashcard-editor/flashcard-editor.component.ts
+++ b/src/app/flashcard-editor/flashcard-editor.component.ts
@@ -18,6 +18,7 @@ import $ from "jquery";
 import { MatDialog, MatDialogModule } from '@angular/material/dialog';
 import { UploadPopupComponent } from '../upload-popup/upload-popup.component';
 import { ImageService } from '../services/image/image.service';
+import { maxText, maxTextImage } from '../utilities/constants';
 
 @Component({
   selector: 'app-flashcard-editor',
@@ -44,6 +45,8 @@ export class FlashcardEditorComponent {
   selectedIndex: number = 0;
   highlight: boolean = true;
   hoverImage: boolean = false;
+  maxText: number = maxText
+  maxTextImage: number = maxTextImage;
 
   @Output() addCardEvent = new EventEmitter<void>;
   @Output() removeCardEvent = new EventEmitter<FlashcardData>;
@@ -93,7 +96,7 @@ export class FlashcardEditorComponent {
       this.addCard();
     }
     if (this.selectedIndex == 0) {
-      this.selectedCard = this._flashcards[1]
+      this.selectedCard = this._flashcards[1];
     } else {
       this.selectedIndex--;
       this.selectedCard = this.flashcards[this.selectedIndex];
@@ -113,19 +116,20 @@ export class FlashcardEditorComponent {
     let dialog = this.dialogRef.open(
       UploadPopupComponent,
       { data: this.selectedCard, disableClose: true}
-    )
+    );
+
     dialog.afterClosed().subscribe(res => {
       if(res.data.path != "") {
-        sessionStorage.setItem(res.data.path, res.data.data)
-        this.images.set(this.selectedCard.id, res.data.path)
+        sessionStorage.setItem(res.data.path, res.data.data);
+        this.images.set(this.selectedCard.id, res.data.path);
         this.selectedCard.image = res.data.path;
       }
-    })
+    });
   }
 
   removeImage() {
-    sessionStorage.removeItem(this.selectedCard.image)
-    this.images.delete(this.selectedCard.id)
+    sessionStorage.removeItem(this.selectedCard.image);
+    this.images.delete(this.selectedCard.id);
     this.selectedCard.image = "";
   }
 }

--- a/src/app/flashcard-editor/flashcard-editor.component.ts
+++ b/src/app/flashcard-editor/flashcard-editor.component.ts
@@ -50,7 +50,7 @@ export class FlashcardEditorComponent {
 
   @Output() addCardEvent = new EventEmitter<void>;
   @Output() removeCardEvent = new EventEmitter<FlashcardData>;
-  @Input() images: Map<number, string> = new Map<number, string>();
+  @Input() cardsToUpdate: Set<number> = new Set<number>();
   @Input() set flashcards(card: FlashcardData[]) {
     this._flashcards = card;
     this.selectedCard = this.flashcards[0];
@@ -119,17 +119,15 @@ export class FlashcardEditorComponent {
     );
 
     dialog.afterClosed().subscribe(res => {
-      if(res.data.path != "") {
-        sessionStorage.setItem(res.data.path, res.data.data);
-        this.images.set(this.selectedCard.id, res.data.path);
-        this.selectedCard.image = res.data.path;
+      if(res.data != "") {
+        this.cardsToUpdate.add(this.selectedCard.id);
+        this.selectedCard.image = res.data;
       }
     });
   }
 
   removeImage() {
-    sessionStorage.removeItem(this.selectedCard.image);
-    this.images.delete(this.selectedCard.id);
+    this.cardsToUpdate.delete(this.selectedCard.id);
     this.selectedCard.image = "";
   }
 }

--- a/src/app/flashcard-editor/flashcard-editor.component.ts
+++ b/src/app/flashcard-editor/flashcard-editor.component.ts
@@ -50,7 +50,6 @@ export class FlashcardEditorComponent {
 
   @Output() addCardEvent = new EventEmitter<void>;
   @Output() removeCardEvent = new EventEmitter<FlashcardData>;
-  @Input() cardsToUpdate: Set<number> = new Set<number>();
   @Input() set flashcards(card: FlashcardData[]) {
     this._flashcards = card;
     this.selectedCard = this.flashcards[0];
@@ -120,14 +119,14 @@ export class FlashcardEditorComponent {
 
     dialog.afterClosed().subscribe(res => {
       if(res.data != "") {
-        this.cardsToUpdate.add(this.selectedCard.id);
-        this.selectedCard.image = res.data;
+        this.imageService.uploadImage(res.data).subscribe(imageId => {
+          this.selectedCard.image = imageId;
+        })
       }
     });
   }
 
   removeImage() {
-    this.cardsToUpdate.delete(this.selectedCard.id);
     this.selectedCard.image = "";
   }
 }

--- a/src/app/flashcard-editor/flashcard-editor.component.ts
+++ b/src/app/flashcard-editor/flashcard-editor.component.ts
@@ -17,6 +17,7 @@ import {
 import $ from "jquery";
 import { MatDialog, MatDialogModule } from '@angular/material/dialog';
 import { UploadPopupComponent } from '../upload-popup/upload-popup.component';
+import { ImageService } from '../services/image/image.service';
 
 @Component({
   selector: 'app-flashcard-editor',
@@ -46,7 +47,7 @@ export class FlashcardEditorComponent {
 
   @Output() addCardEvent = new EventEmitter<void>;
   @Output() removeCardEvent = new EventEmitter<FlashcardData>;
-  @Input() images: Map<string, string> = new Map<string, string>();
+  @Input() images: Map<number, string> = new Map<number, string>();
   @Input() set flashcards(card: FlashcardData[]) {
     this._flashcards = card;
     this.selectedCard = this.flashcards[0];
@@ -56,7 +57,8 @@ export class FlashcardEditorComponent {
   }
 
   constructor(
-    private dialogRef: MatDialog
+    private dialogRef: MatDialog,
+    protected imageService: ImageService
   ) {}
 
   ngAfterViewChecked() {
@@ -86,6 +88,7 @@ export class FlashcardEditorComponent {
   }
 
   removeCard(flashcard: FlashcardData) {
+    this.removeImage();
     if (this.selectedIndex == 0 && this._flashcards.length == 1) {
       this.addCard();
     }
@@ -109,18 +112,20 @@ export class FlashcardEditorComponent {
   uploadImage() {
     let dialog = this.dialogRef.open(
       UploadPopupComponent,
-      {width: "50vw", data: this.selectedCard, disableClose: true}
+      { data: this.selectedCard, disableClose: true}
     )
     dialog.afterClosed().subscribe(res => {
       if(res.data.path != "") {
-        this.images.set(res.data.path, res.data.data);
+        sessionStorage.setItem(res.data.path, res.data.data)
+        this.images.set(this.selectedCard.id, res.data.path)
         this.selectedCard.image = res.data.path;
       }
     })
   }
 
   removeImage() {
-    this.images.delete(this.selectedCard.image)
+    sessionStorage.removeItem(this.selectedCard.image)
+    this.images.delete(this.selectedCard.id)
     this.selectedCard.image = "";
   }
 }

--- a/src/app/flashcard/flashcard.component.html
+++ b/src/app/flashcard/flashcard.component.html
@@ -31,7 +31,7 @@
           </div>
           <img class="flashcard-image"
             *ngIf="flashcard.hasImage();"
-            src={{flashcard.image}}>
+            src={{this.imageService.loadImage(flashcard.image)}}>
         </div>
       </div>
     </div>

--- a/src/app/flashcard/flashcard.component.ts
+++ b/src/app/flashcard/flashcard.component.ts
@@ -39,7 +39,7 @@ export class FlashcardComponent implements OnInit{
   isFlipped: boolean = false;
 
   constructor(protected imageService: ImageService) {
-    this._flashcard = new FlashcardData('error', 'error')
+    this._flashcard = new FlashcardData('error', 'error');
   }
 
   ngOnInit(): void {

--- a/src/app/flashcard/flashcard.component.ts
+++ b/src/app/flashcard/flashcard.component.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 import { MatIconModule } from '@angular/material/icon';
 import { FlashcardData } from '../data-models/flashcard-model';
 import { ImageService } from '../services/image/image.service';
+import { flashcardBaseHeight, flashcardBaseWidth } from '../utilities/constants';
 
 @Component({
   selector: 'app-flashcard',
@@ -32,12 +33,12 @@ export class FlashcardComponent implements OnInit{
     return this._flashcard;
   }
 
-  protected height: number = 282 * this.scaleFactor;
-  protected width: number = 500 * this.scaleFactor;
+  protected height: number = flashcardBaseHeight * this.scaleFactor;
+  protected width: number = flashcardBaseWidth * this.scaleFactor;
 
   isFlipped: boolean = false;
 
-  constructor(protected imageService: ImageService){
+  constructor(protected imageService: ImageService) {
     this._flashcard = new FlashcardData('error', 'error')
   }
 
@@ -50,8 +51,8 @@ export class FlashcardComponent implements OnInit{
 
   @HostListener('window:resize', ['$event'])
   onResize() {
-    this.height = 282 * this.scaleFactor;
-    this.width = 500 * this.scaleFactor;
+    this.height = flashcardBaseHeight * this.scaleFactor;
+    this.width = flashcardBaseWidth * this.scaleFactor;
   }
 
   flipCard() {

--- a/src/app/flashcard/flashcard.component.ts
+++ b/src/app/flashcard/flashcard.component.ts
@@ -2,6 +2,7 @@ import { Component, Input, HostListener, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MatIconModule } from '@angular/material/icon';
 import { FlashcardData } from '../data-models/flashcard-model';
+import { ImageService } from '../services/image/image.service';
 
 @Component({
   selector: 'app-flashcard',
@@ -36,7 +37,7 @@ export class FlashcardComponent implements OnInit{
 
   isFlipped: boolean = false;
 
-  constructor(){
+  constructor(protected imageService: ImageService){
     this._flashcard = new FlashcardData('error', 'error')
   }
 

--- a/src/app/sequence-card/sequence-card.component.ts
+++ b/src/app/sequence-card/sequence-card.component.ts
@@ -34,10 +34,6 @@ export class SequenceCardComponent{
     e.stopPropagation();
   }
 
-  expand(e: Event) {
-    e.stopPropagation();
-  }
-
   removeFromSequence(flashcard: FlashcardData, e: Event) {
     this.removeFromSeqEvent.emit(flashcard);
     e.stopPropagation();

--- a/src/app/sequence-editor/sequence-editor.component.ts
+++ b/src/app/sequence-editor/sequence-editor.component.ts
@@ -17,6 +17,7 @@ import { MatInputModule } from '@angular/material/input';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { FormsModule } from '@angular/forms';
 import { calculateScaleFactor } from '../utilities/calculate-scaler';
+import { seqEditPreviewHeightSF, seqEditPreviewWidthSF } from '../utilities/constants';
 
 @Component({
     selector: 'app-sequence-editor',
@@ -38,12 +39,8 @@ import { calculateScaleFactor } from '../utilities/calculate-scaler';
     ]
 })
 export class SequenceEditorComponent {
-  /** Flashcard width scale factor constant */
-  private readonly widthSF = (300 / 1280);
-  /** Flashcard height scale factor constant */
-  private readonly heightSF = (168 / 720);
   /** Flashcard scale factor */
-  cardScaleFactor: number = calculateScaleFactor(this.widthSF, this.heightSF);;
+  cardScaleFactor: number = calculateScaleFactor(seqEditPreviewWidthSF, seqEditPreviewHeightSF);;
   _sequences: SequenceData[] = [];
   selectedSequence: SequenceData | undefined = undefined;
   _flashcards: FlashcardData[] = [];
@@ -51,7 +48,7 @@ export class SequenceEditorComponent {
   filteredCards: FlashcardData[] = [];
   searchtext: any;
   items: any[] = this._sequences;
-  
+
   @Output() addSequenceEvent = new EventEmitter();
   @Output() removeSequenceEvent = new EventEmitter();
 
@@ -81,9 +78,9 @@ export class SequenceEditorComponent {
 
   @HostListener('window:resize', ['$event'])
   onResize(event: Event) {
-    this.cardScaleFactor = calculateScaleFactor(this.widthSF, this.heightSF);
+    this.cardScaleFactor = calculateScaleFactor(seqEditPreviewWidthSF, seqEditPreviewHeightSF);
   }
-  
+
   addToSequence(flashcard: FlashcardData) {
     if(this.selectedSequence != undefined) {
       this.selectedSequence.addCard(flashcard);
@@ -118,7 +115,7 @@ export class SequenceEditorComponent {
       moveItemInArray(this.selectedSequence.cardList, event.previousIndex, event.currentIndex);
     }
   }
-  
+
   filterItems(filterValue: string) {
     this.filteredCards = this.flashcards.filter(
       item => item.term.toLowerCase().includes(filterValue.toLowerCase()));

--- a/src/app/services/auth/auth.service.ts
+++ b/src/app/services/auth/auth.service.ts
@@ -1,13 +1,25 @@
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 
+/**
+ * Abstract class that defines the standard methods for all Auth Services.
+ */
 @Injectable({
   providedIn: 'root'
 })
 export abstract class AuthService {
+  /**
+   * Signs in the user and return's the uid
+   */
   abstract signInWithGoogle(): Observable<string>;
 
+  /**
+   * Invalidates user session and signs out user
+   */
   abstract signOut(): void;
 
+  /**
+   * Checks that a user is signed in
+   */
   abstract checkSignIn(): boolean;
 }

--- a/src/app/services/image/image-dev.service.ts
+++ b/src/app/services/image/image-dev.service.ts
@@ -1,0 +1,17 @@
+import { Injectable } from "@angular/core";
+import { ImageService } from "./image.service"
+import { Observable, of } from "rxjs";
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ImageDevService extends ImageService {
+
+  override loadImage(path: string): Observable<string> {
+      return of("Hello World");
+  }
+
+  override uploadImage(image: Blob): Observable<string> {
+    return of("Hello World");
+  }
+}

--- a/src/app/services/image/image-fake.service.ts
+++ b/src/app/services/image/image-fake.service.ts
@@ -9,7 +9,7 @@ export class ImageDevService extends ImageService {
 
   override loadImage(path: string): string {
     if(sessionStorage.getItem(path)){
-      return <string>sessionStorage.getItem(path)
+      return <string>sessionStorage.getItem(path);
     }
     return path;
   }

--- a/src/app/services/image/image-fake.service.ts
+++ b/src/app/services/image/image-fake.service.ts
@@ -8,8 +8,8 @@ import { Observable, of } from "rxjs";
 export class ImageDevService extends ImageService {
 
   override loadImage(path: string): string {
-    if(sessionStorage.getItem(path)){
-      return <string>sessionStorage.getItem(path);
+    if(path.substring(0, 11) == "data:image/"){
+      return path;
     }
     return path;
   }

--- a/src/app/services/image/image-fake.service.ts
+++ b/src/app/services/image/image-fake.service.ts
@@ -8,10 +8,10 @@ import { Observable, of } from "rxjs";
 export class ImageDevService extends ImageService {
 
   override loadImage(path: string): Observable<string> {
-      return of("Hello World");
+      return of("assets/images/lemon-pic.jpeg");
   }
 
   override uploadImage(image: Blob): Observable<string> {
-    return of("Hello World");
+    return of("assets/images/lemon-pic.jpeg");
   }
 }

--- a/src/app/services/image/image-fake.service.ts
+++ b/src/app/services/image/image-fake.service.ts
@@ -7,11 +7,14 @@ import { Observable, of } from "rxjs";
 })
 export class ImageDevService extends ImageService {
 
-  override loadImage(path: string): Observable<string> {
-      return of("assets/images/lemon-pic.jpeg");
+  override loadImage(path: string): string {
+    if(sessionStorage.getItem(path)){
+      return <string>sessionStorage.getItem(path)
+    }
+    return path;
   }
 
-  override uploadImage(image: Blob): Observable<string> {
+  override uploadImage(image: string): Observable<string> {
     return of("assets/images/lemon-pic.jpeg");
   }
 }

--- a/src/app/services/image/image-fake.service.ts
+++ b/src/app/services/image/image-fake.service.ts
@@ -8,9 +8,6 @@ import { Observable, of } from "rxjs";
 export class ImageDevService extends ImageService {
 
   override loadImage(path: string): string {
-    if(path.substring(0, 11) == "data:image/"){
-      return path;
-    }
     return path;
   }
 

--- a/src/app/services/image/image-service-module.ts
+++ b/src/app/services/image/image-service-module.ts
@@ -1,0 +1,7 @@
+/**
+ * @module
+ * @description Imports all Services for authentication
+ */
+export * from './image.service';
+export * from './image-fake.service';
+//export *  from './auth-firebase.service';

--- a/src/app/services/image/image.service.ts
+++ b/src/app/services/image/image.service.ts
@@ -1,11 +1,22 @@
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 
+/**
+ * Abstract class that defines the standard methods for all Image Services.
+ */
 @Injectable({
   providedIn: 'root'
 })
 export abstract class ImageService {
+  /**
+   * Returns image data as a string of byte data
+   * @param path the path or url of the image to be loaded
+   */
   abstract loadImage(path: string): string;
 
+  /**
+   * Returs the file/path name of the stored image to be accessed later
+   * @param image the byte data of the image to be uploaded
+   */
   abstract uploadImage(image: string): Observable<string>;
 }

--- a/src/app/services/image/image.service.ts
+++ b/src/app/services/image/image.service.ts
@@ -5,7 +5,7 @@ import { Observable } from 'rxjs';
   providedIn: 'root'
 })
 export abstract class ImageService {
-  abstract loadImage(path: string): Observable<string>;
+  abstract loadImage(path: string): string;
 
-  abstract uploadImage(image: Blob): Observable<string>;
+  abstract uploadImage(image: string): Observable<string>;
 }

--- a/src/app/services/image/image.service.ts
+++ b/src/app/services/image/image.service.ts
@@ -1,0 +1,11 @@
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root'
+})
+export abstract class ImageService {
+  abstract loadImage(path: string): Observable<string>;
+
+  abstract uploadImage(image: Blob): Observable<string>;
+}

--- a/src/app/study-flashcard/study-flashcard.component.ts
+++ b/src/app/study-flashcard/study-flashcard.component.ts
@@ -10,7 +10,7 @@ import { ActivatedRoute } from '@angular/router';
 import { calculateScaleFactor } from '../utilities/calculate-scaler';
 import { UserInfoService } from '../services/user/user-info.service';
 import { StudySetData } from '../data-models/studyset-model';
-
+import { studyFlashcardHeightSF, studyFlashcardWidthSF } from '../utilities/constants';
 @Component({
   selector: 'app-study-flashcard',
   standalone: true,
@@ -25,9 +25,7 @@ import { StudySetData } from '../data-models/studyset-model';
 })
 export class StudyFlashcardComponent {
   /** Constant used for calculating flashcard scale */
-  private readonly widthSF = (880 / 1280);
-  private readonly heightSF = (496 / 720);
-  cardScaleFactor: number = calculateScaleFactor(this.widthSF, this.heightSF);
+  cardScaleFactor: number = calculateScaleFactor(studyFlashcardWidthSF, studyFlashcardHeightSF);
   flashcards: FlashcardData[] = [];
   currentFlashcard: FlashcardData = new FlashcardData();
   currentCardIndex: number = 0;
@@ -87,6 +85,6 @@ export class StudyFlashcardComponent {
 
   @HostListener('window:resize', ['$event'])
   onResize(event: Event) {
-    this.cardScaleFactor = calculateScaleFactor(this.widthSF, this.heightSF);
+    this.cardScaleFactor = calculateScaleFactor(studyFlashcardWidthSF, studyFlashcardHeightSF);
   }
 }

--- a/src/app/upload-popup/upload-popup.component.html
+++ b/src/app/upload-popup/upload-popup.component.html
@@ -8,7 +8,10 @@
   <img class="preview-image" src={{this.data}}>
 </mat-dialog-content>
 <mat-dialog-actions>
-  <input id="selected-image" #selectedImage type="file" *ngIf="flashcard.definition.length <= 72; else stopMessage"(change)="uploadImage(selectedImage)">
+  <input id="selected-image" #selectedImage
+    *ngIf="flashcard.definition.length <= 72; else stopMessage"(change)="uploadImage(selectedImage)"
+    type="file"
+    accept="image/*">
   <ng-template #stopMessage>
     <p id="stop-message">Sorry. You cannot add image unless your definition is less than 72 characters.</p>
   </ng-template>

--- a/src/app/upload-popup/upload-popup.component.html
+++ b/src/app/upload-popup/upload-popup.component.html
@@ -9,11 +9,11 @@
 </mat-dialog-content>
 <mat-dialog-actions>
   <input id="selected-image" #selectedImage
-    *ngIf="flashcard.definition.length <= 72; else stopMessage"(change)="uploadImage(selectedImage)"
+    *ngIf="flashcard.definition.length <= maxTextImage; else stopMessage"(change)="uploadImage(selectedImage)"
     type="file"
     accept="image/*">
   <ng-template #stopMessage>
-    <p id="stop-message">Sorry. You cannot add image unless your definition is less than 72 characters.</p>
+    <p id="stop-message">Sorry. You cannot add image unless your definition is less than {{maxTextImage}} characters.</p>
   </ng-template>
   <button mat-flat-button *ngIf="data!=&quot;&quot;" (click)="saveClose()">
     Submit

--- a/src/app/upload-popup/upload-popup.component.html
+++ b/src/app/upload-popup/upload-popup.component.html
@@ -4,15 +4,15 @@
     <mat-icon>close</mat-icon>
   </button>
 </div>
-<mat-dialog-content *ngIf="this.flashcard.hasImage()">
-  <img class="preview-image" src={{this.imageData}}>
+<mat-dialog-content *ngIf="data!=&quot;&quot;">
+  <img class="preview-image" src={{this.data}}>
 </mat-dialog-content>
 <mat-dialog-actions>
   <input id="selected-image" #selectedImage type="file" *ngIf="flashcard.definition.length <= 72; else stopMessage"(change)="uploadImage(selectedImage)">
   <ng-template #stopMessage>
     <p id="stop-message">Sorry. You cannot add image unless your definition is less than 72 characters.</p>
   </ng-template>
-  <button mat-icon-button *ngIf="flashcard.hasImage()" (click)="removeImage()">
-    <mat-icon>delete-outline</mat-icon>
+  <button mat-flat-button *ngIf="data!=&quot;&quot;" (click)="saveClose()">
+    Submit
   </button>
 </mat-dialog-actions>

--- a/src/app/upload-popup/upload-popup.component.html
+++ b/src/app/upload-popup/upload-popup.component.html
@@ -1,0 +1,18 @@
+<div id="image-banner">
+  <h2 mat-dialog-title>Upload Image</h2>
+  <button id="close" mat-icon-button (click)="close()">
+    <mat-icon>close</mat-icon>
+  </button>
+</div>
+<mat-dialog-content *ngIf="this.flashcard.hasImage()">
+  <img class="preview-image" src={{this.imageData}}>
+</mat-dialog-content>
+<mat-dialog-actions>
+  <input id="selected-image" #selectedImage type="file" *ngIf="flashcard.definition.length <= 72; else stopMessage"(change)="uploadImage(selectedImage)">
+  <ng-template #stopMessage>
+    <p id="stop-message">Sorry. You cannot add image unless your definition is less than 72 characters.</p>
+  </ng-template>
+  <button mat-icon-button *ngIf="flashcard.hasImage()" (click)="removeImage()">
+    <mat-icon>delete-outline</mat-icon>
+  </button>
+</mat-dialog-actions>

--- a/src/app/upload-popup/upload-popup.component.scss
+++ b/src/app/upload-popup/upload-popup.component.scss
@@ -1,0 +1,23 @@
+.preview-image {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
+#close {
+  margin-left: auto;
+  margin-right: 16px;
+}
+
+#image-banner {
+  display: flex;
+  align-items: center;
+}
+
+#selected-image {
+  margin-right: auto;
+}
+
+#stop-message {
+  margin-right: auto;
+}

--- a/src/app/upload-popup/upload-popup.component.spec.ts
+++ b/src/app/upload-popup/upload-popup.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { UploadPopupComponent } from './upload-popup.component';
+
+describe('UploadPopupComponent', () => {
+  let component: UploadPopupComponent;
+  let fixture: ComponentFixture<UploadPopupComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [UploadPopupComponent]
+    })
+    .compileComponents();
+    
+    fixture = TestBed.createComponent(UploadPopupComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/upload-popup/upload-popup.component.ts
+++ b/src/app/upload-popup/upload-popup.component.ts
@@ -10,6 +10,7 @@ import { FlashcardData } from '../data-models/flashcard-model';
 import { CommonModule } from '@angular/common';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIcon } from '@angular/material/icon';
+import { maxTextImage } from '../utilities/constants';
 
 @Component({
   selector: 'app-upload-popup',
@@ -21,6 +22,7 @@ import { MatIcon } from '@angular/material/icon';
 export class UploadPopupComponent {
   path: string = "";
   data: string = "";
+  maxTextImage: number = maxTextImage;
 
   constructor(
     public dialogRef: MatDialogRef<FlashcardEditorComponent>,
@@ -33,7 +35,6 @@ export class UploadPopupComponent {
     reader.addEventListener("load", () => {
       var file = (<HTMLInputElement>document.getElementById("selected-image")).value;
       this.path = this.flashcard.id + file;
-      console.log(file);
       this.data = <string>reader.result;
     })
     reader.readAsDataURL(selectedImage.files[0])
@@ -51,6 +52,6 @@ export class UploadPopupComponent {
   }
 
   saveClose() {
-    this.dialogRef.close({data: {path: this.path, data: this.data}})
+    this.dialogRef.close({data: {path: this.path, data: this.data}});
   }
 }

--- a/src/app/upload-popup/upload-popup.component.ts
+++ b/src/app/upload-popup/upload-popup.component.ts
@@ -1,0 +1,55 @@
+import { Component, Inject } from '@angular/core';
+import {
+  MAT_DIALOG_DATA,
+  MatDialogRef,
+  MatDialogContent,
+  MatDialogActions,
+  MatDialogTitle } from '@angular/material/dialog';
+import { FlashcardEditorComponent } from '../flashcard-editor/flashcard-editor.component';
+import { FlashcardData } from '../data-models/flashcard-model';
+import { ImageService } from '../services/image/image.service';
+import { CommonModule } from '@angular/common';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIcon } from '@angular/material/icon';
+
+@Component({
+  selector: 'app-upload-popup',
+  standalone: true,
+  imports: [MatDialogContent, MatDialogActions, MatDialogTitle, CommonModule, MatButtonModule, MatIcon],
+  templateUrl: './upload-popup.component.html',
+  styleUrl: './upload-popup.component.scss'
+})
+export class UploadPopupComponent {
+  imageData: string = "";
+
+  constructor(
+    protected imageService: ImageService,
+    public dialogRef: MatDialogRef<FlashcardEditorComponent>,
+    @Inject(MAT_DIALOG_DATA) public flashcard: FlashcardData
+  ) {}
+
+  loadImage() {
+    this.imageService.loadImage(this.flashcard.image).subscribe(res => {
+      console.log(res);
+      this.imageData = res;
+    });
+  }
+
+  uploadImage(selectedImage: any) {
+    this.imageService.uploadImage(selectedImage.files[0]).subscribe((res) => {
+      console.log(res);
+      this.flashcard.image = res;
+      this.loadImage();
+    });
+  }
+
+  removeImage() {
+    this.flashcard.image = "";
+    var file = <HTMLInputElement>document.getElementById("selected-image");
+    file.value = file.defaultValue;
+  }
+
+  close() {
+    this.dialogRef.close();
+  }
+}

--- a/src/app/upload-popup/upload-popup.component.ts
+++ b/src/app/upload-popup/upload-popup.component.ts
@@ -33,8 +33,8 @@ export class UploadPopupComponent {
 
     reader.addEventListener("load", () => {
       this.data = <string>reader.result;
-    })
-    reader.readAsDataURL(selectedImage.files[0])
+    });
+    reader.readAsDataURL(selectedImage.files[0]);
   }
 
   close() {

--- a/src/app/upload-popup/upload-popup.component.ts
+++ b/src/app/upload-popup/upload-popup.component.ts
@@ -7,15 +7,9 @@ import {
   MatDialogTitle } from '@angular/material/dialog';
 import { FlashcardEditorComponent } from '../flashcard-editor/flashcard-editor.component';
 import { FlashcardData } from '../data-models/flashcard-model';
-import { ImageService } from '../services/image/image.service';
 import { CommonModule } from '@angular/common';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIcon } from '@angular/material/icon';
-
-interface UploadedImage {
-  path: string;
-  data: string;
-}
 
 @Component({
   selector: 'app-upload-popup',
@@ -29,7 +23,6 @@ export class UploadPopupComponent {
   data: string = "";
 
   constructor(
-    protected imageService: ImageService,
     public dialogRef: MatDialogRef<FlashcardEditorComponent>,
     @Inject(MAT_DIALOG_DATA) public flashcard: FlashcardData
   ) {}
@@ -39,7 +32,7 @@ export class UploadPopupComponent {
 
     reader.addEventListener("load", () => {
       var file = (<HTMLInputElement>document.getElementById("selected-image")).value;
-      this.path = file;
+      this.path = this.flashcard.id + file;
       console.log(file);
       this.data = <string>reader.result;
     })

--- a/src/app/upload-popup/upload-popup.component.ts
+++ b/src/app/upload-popup/upload-popup.component.ts
@@ -12,6 +12,11 @@ import { CommonModule } from '@angular/common';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIcon } from '@angular/material/icon';
 
+interface UploadedImage {
+  path: string;
+  data: string;
+}
+
 @Component({
   selector: 'app-upload-popup',
   standalone: true,
@@ -20,7 +25,8 @@ import { MatIcon } from '@angular/material/icon';
   styleUrl: './upload-popup.component.scss'
 })
 export class UploadPopupComponent {
-  imageData: string = "";
+  path: string = "";
+  data: string = "";
 
   constructor(
     protected imageService: ImageService,
@@ -28,28 +34,30 @@ export class UploadPopupComponent {
     @Inject(MAT_DIALOG_DATA) public flashcard: FlashcardData
   ) {}
 
-  loadImage() {
-    this.imageService.loadImage(this.flashcard.image).subscribe(res => {
-      console.log(res);
-      this.imageData = res;
-    });
-  }
-
   uploadImage(selectedImage: any) {
-    this.imageService.uploadImage(selectedImage.files[0]).subscribe((res) => {
-      console.log(res);
-      this.flashcard.image = res;
-      this.loadImage();
-    });
+    const reader = new FileReader();
+
+    reader.addEventListener("load", () => {
+      var file = (<HTMLInputElement>document.getElementById("selected-image")).value;
+      this.path = file;
+      console.log(file);
+      this.data = <string>reader.result;
+    })
+    reader.readAsDataURL(selectedImage.files[0])
   }
 
   removeImage() {
-    this.flashcard.image = "";
+    this.path = "";
+    this.data = "";
     var file = <HTMLInputElement>document.getElementById("selected-image");
     file.value = file.defaultValue;
   }
 
   close() {
-    this.dialogRef.close();
+    this.dialogRef.close({data: {path: "", data: ""}});
+  }
+
+  saveClose() {
+    this.dialogRef.close({data: {path: this.path, data: this.data}})
   }
 }

--- a/src/app/upload-popup/upload-popup.component.ts
+++ b/src/app/upload-popup/upload-popup.component.ts
@@ -20,7 +20,6 @@ import { maxTextImage } from '../utilities/constants';
   styleUrl: './upload-popup.component.scss'
 })
 export class UploadPopupComponent {
-  path: string = "";
   data: string = "";
   maxTextImage: number = maxTextImage;
 
@@ -33,25 +32,16 @@ export class UploadPopupComponent {
     const reader = new FileReader();
 
     reader.addEventListener("load", () => {
-      var file = (<HTMLInputElement>document.getElementById("selected-image")).value;
-      this.path = this.flashcard.id + file;
       this.data = <string>reader.result;
     })
     reader.readAsDataURL(selectedImage.files[0])
   }
 
-  removeImage() {
-    this.path = "";
-    this.data = "";
-    var file = <HTMLInputElement>document.getElementById("selected-image");
-    file.value = file.defaultValue;
-  }
-
   close() {
-    this.dialogRef.close({data: {path: "", data: ""}});
+    this.dialogRef.close({data: ""});
   }
 
   saveClose() {
-    this.dialogRef.close({data: {path: this.path, data: this.data}});
+    this.dialogRef.close({data: this.data});
   }
 }

--- a/src/app/utilities/calculate-scaler.ts
+++ b/src/app/utilities/calculate-scaler.ts
@@ -1,6 +1,8 @@
+import { flashcardBaseHeight, flashcardBaseWidth } from "./constants";
+
 export function calculateScaleFactor(widthSF: number=1, heightSF: number=1, shift: number=0) {
   return Math.min(
-    (window.innerWidth * widthSF + shift) / 500,
-    (window.innerHeight * heightSF + shift) / 282
+    (window.innerWidth * widthSF + shift) / flashcardBaseWidth,
+    (window.innerHeight * heightSF + shift) / flashcardBaseHeight
   );
 }

--- a/src/app/utilities/constants.ts
+++ b/src/app/utilities/constants.ts
@@ -1,0 +1,23 @@
+export const maxText = 144;
+
+export const maxTextImage = 72;
+
+export const flashcardBaseWidth = 500;
+
+export const flashcardBaseHeight = 282;
+
+const baseScreenWidth = 1280;
+
+const baseScreenHeight = 720;
+
+export const studyFlashcardWidthSF = 880 / baseScreenWidth;
+
+export const studyFlashcardHeightSF = 496 / baseScreenHeight;
+
+export const seqEditPreviewWidthSF = 300 / baseScreenWidth;
+
+export const seqEditPreviewHeightSF = 168 / baseScreenHeight;
+
+export const ecPreviewWidthSF = 0.22;
+
+export const ecPreviewShift = -46;

--- a/src/app/view-fc-card/view-fc-card.component.html
+++ b/src/app/view-fc-card/view-fc-card.component.html
@@ -4,6 +4,6 @@
   </mat-card>
   <mat-card class="view-card padding-medium">
     <mat-card-title id="card-back">{{ flashcard.definition }}</mat-card-title>
-    <img class="flashcard-image" *ngIf="flashcard.hasImage();" src={{flashcard.image}}>
+    <img class="flashcard-image" *ngIf="flashcard.hasImage();" src={{this.imageService.loadImage(flashcard.image)}}>
   </mat-card>
 </div>

--- a/src/app/view-fc-card/view-fc-card.component.ts
+++ b/src/app/view-fc-card/view-fc-card.component.ts
@@ -2,6 +2,7 @@ import { Component, Input } from '@angular/core';
 import { FlashcardData } from '../data-models/flashcard-model';
 import { MatCardModule } from '@angular/material/card';
 import { CommonModule } from '@angular/common';
+import { ImageService } from '../services/image/image.service';
 
 @Component({
   selector: 'app-view-fc-card',
@@ -12,4 +13,6 @@ import { CommonModule } from '@angular/common';
 })
 export class ViewFcCardComponent {
   @Input() flashcard: FlashcardData = new FlashcardData("error", "error");
+
+  constructor(protected imageService: ImageService) {}
 }


### PR DESCRIPTION
fixes #27 

- Fake Image service was created. It only uploads the lemon image.
- Added add image button to icons in flashcard editor
  - When pressed, a popup appears that allows the user to select an image file from their file system
- When the popup is closed, the image is stored in to sessionStorage for access and a log is kept of which cards gained new images
- The popup restricts the user from uploading an image if their definition is over 72 characters and the add image is also hidden when there is already an image on a flashcard.
- The image is displayed next to the definition box and can be deleted when pressing a trash icon that appears when hovering the image
- All loading of images is now done through image service
- Images are uploaded through the image service when the done button in ec-study-set is pressed updating the flashcards with newly assigned image urls
  - With the dev service, it always returns the lemon image saved in assets
- Images stored in sessionStorage are deleted when ever the user leaves the ec-page

## Notes
- Through my work, I have discovered that browsers automatically cache images. You can find them in the network tab of the developer tools. Because of this we will likely not have to implement caching for images directly in browser.
  - The use of sessionStorage in this work is to save the image in an accessible place before the images are actually saved to the database. Not really for caching