### PR TITLE
Fix overflow with flashcard preview in set-preview-component

### DIFF
--- a/src/app/set-preview-card/set-preview-card.component.scss
+++ b/src/app/set-preview-card/set-preview-card.component.scss
@@ -70,7 +70,7 @@
   line-height: 1.2em;
   padding: 4px;
   margin:auto;
-  max-width: 90%;
+  word-break: break-word;
   -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;
   overflow: hidden;

--- a/src/app/set-preview-card/set-preview-card.component.scss
+++ b/src/app/set-preview-card/set-preview-card.component.scss
@@ -70,6 +70,7 @@
   line-height: 1.2em;
   padding: 4px;
   margin:auto;
+  max-width: 90%;
   -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;
   overflow: hidden;


### PR DESCRIPTION
Added word break to break single words that would overflow out of the box in the flashcard previews of the set-preview-cards (can be seen on the homepage)